### PR TITLE
Slicer module

### DIFF
--- a/bin/wm_apply_ORG_atlas_to_subject.sh
+++ b/bin/wm_apply_ORG_atlas_to_subject.sh
@@ -132,7 +132,7 @@ if [ $DiffMeasure == 1 ]; then
 		echo "ERROR: -m path to FiberTractMeasurements Module must be provided."
 		echo ""
 		Usage
-	elif [ ! -f $FiberTractMeasurementsCLI ]; then
+	elif [ ! -f "$FiberTractMeasurementsCLI" ]; then
 		echo "ERROR: FiberTractMeasurements Module does not exist."
 		echo ""
 		Usage

--- a/bin/wm_apply_ORG_atlas_to_subject.sh
+++ b/bin/wm_apply_ORG_atlas_to_subject.sh
@@ -128,14 +128,16 @@ else
 fi
 
 if [ $DiffMeasure == 1 ]; then
+    tmp=($FiberTractMeasurementsCLI)
 	if [ -z "$FiberTractMeasurementsCLI" ] ; then
 		echo "ERROR: -m path to FiberTractMeasurements Module must be provided."
 		echo ""
 		Usage
-	elif [ ! -f "$FiberTractMeasurementsCLI" ]; then
-		echo "ERROR: FiberTractMeasurements Module does not exist."
-		echo ""
-		Usage
+	
+    # check existence of the last string in $FiberTractMeasurementsCLI
+    elif [ ! -f ${tmp[-1]} ]; then
+        echo "WARN: FiberTractMeasurements could not be found, program may fail."
+        echo ""
 	fi
 fi
 

--- a/bin/wm_apply_ORG_atlas_to_subject.sh
+++ b/bin/wm_apply_ORG_atlas_to_subject.sh
@@ -295,10 +295,10 @@ if [ "$RegMode" == "rig" ]; then
 	if [ ! -f $FiberClustersInTractographySpace/cluster_00800.vtp ]; then
 		if [ $VX == 0 ]; then
 			wm_harden_transform.py -i -t $tfm \
-				$FiberClusteringOutlierRemFolder/${FCcaseID}_outlier_removed $FiberClustersInTractographySpace $SlicerPath
+				$FiberClusteringOutlierRemFolder/${FCcaseID}_outlier_removed $FiberClustersInTractographySpace "$SlicerPath"
 		else
 			xvfb-run wm_harden_transform.py -i -t $tfm \
-				$FiberClusteringOutlierRemFolder/${FCcaseID}_outlier_removed $FiberClustersInTractographySpace $SlicerPath
+				$FiberClusteringOutlierRemFolder/${FCcaseID}_outlier_removed $FiberClustersInTractographySpace "$SlicerPath"
 		fi
 	else
 		echo " - transform has been done."
@@ -310,10 +310,10 @@ elif [ "$RegMode" == "nonrig" ]; then
 	if [ ! -f $FiberClustersInTractographySpace/tmp/cluster_00800.vtp ]; then
 		if [ $VX == 0 ]; then
 			wm_harden_transform.py -i -t $tfm \
-				$FiberClusteringOutlierRemFolder/${FCcaseID}_outlier_removed $FiberClustersInTractographySpace/tmp $SlicerPath
+				$FiberClusteringOutlierRemFolder/${FCcaseID}_outlier_removed $FiberClustersInTractographySpace/tmp "$SlicerPath"
 		else
 			xvfb-run wm_harden_transform.py -i -t $tfm \
-				$FiberClusteringOutlierRemFolder/${FCcaseID}_outlier_removed $FiberClustersInTractographySpace/tmp $SlicerPath
+				$FiberClusteringOutlierRemFolder/${FCcaseID}_outlier_removed $FiberClustersInTractographySpace/tmp "$SlicerPath"
 		fi
 	else
 		echo " - transform has been done."
@@ -324,10 +324,10 @@ elif [ "$RegMode" == "nonrig" ]; then
 	if [ ! -f $FiberClustersInTractographySpace/cluster_00800.vtp ]; then
 		if [ $VX == 0 ]; then
 			wm_harden_transform.py -i -t $tfm \
-				$FiberClustersInTractographySpace/tmp $FiberClustersInTractographySpace $SlicerPath
+				$FiberClustersInTractographySpace/tmp $FiberClustersInTractographySpace "$SlicerPath"
 		else
 			xvfb-run wm_harden_transform.py -i -t $tfm \
-				$FiberClustersInTractographySpace/tmp $FiberClustersInTractographySpace $SlicerPath
+				$FiberClustersInTractographySpace/tmp $FiberClustersInTractographySpace "$SlicerPath"
 		fi
 	else
 		echo " - transform has been done."

--- a/bin/wm_apply_ORG_atlas_to_subject.sh
+++ b/bin/wm_apply_ORG_atlas_to_subject.sh
@@ -390,19 +390,19 @@ if [ $DiffMeasure == 1 ]; then
 	echo "<wm_apply_ORG_atlas_to_subject> Report diffusion measurements of fiber clusters."
 	if [ ! -f $SeparatedClustersFolder/diffusion_measurements_commissural.csv ]; then
 		wm_diffusion_measurements.py \
-			$SeparatedClustersFolder/tracts_commissural $SeparatedClustersFolder/diffusion_measurements_commissural.csv $FiberTractMeasurementsCLI
+			$SeparatedClustersFolder/tracts_commissural $SeparatedClustersFolder/diffusion_measurements_commissural.csv "$FiberTractMeasurementsCLI"
 	else
 		echo " - diffusion measurements of commissural clusters has been done."
 	fi
 	if [ ! -f $SeparatedClustersFolder/diffusion_measurements_left_hemisphere.csv ]; then
 		wm_diffusion_measurements.py \
-			$SeparatedClustersFolder/tracts_left_hemisphere $SeparatedClustersFolder/diffusion_measurements_left_hemisphere.csv $FiberTractMeasurementsCLI
+			$SeparatedClustersFolder/tracts_left_hemisphere $SeparatedClustersFolder/diffusion_measurements_left_hemisphere.csv "$FiberTractMeasurementsCLI"
 	else
 		echo " - diffusion measurements of left hemisphere clusters has been done."
 	fi
 	if [ ! -f $SeparatedClustersFolder/diffusion_measurements_right_hemisphere.csv ]; then
 		wm_diffusion_measurements.py \
-			$SeparatedClustersFolder/tracts_right_hemisphere $SeparatedClustersFolder/diffusion_measurements_right_hemisphere.csv $FiberTractMeasurementsCLI
+			$SeparatedClustersFolder/tracts_right_hemisphere $SeparatedClustersFolder/diffusion_measurements_right_hemisphere.csv "$FiberTractMeasurementsCLI"
 	else
 		echo " - diffusion measurements of right hemisphere clusters has been done."
 	fi
@@ -423,7 +423,7 @@ if [ $DiffMeasure == 1 ]; then
 	echo "<wm_apply_ORG_atlas_to_subject> Report diffusion measurements of the anatomical tracts."
 	if [ ! -f $AnatomicalTractsFolder/diffusion_measurements_anatomical_tracts.csv ]; then
 		wm_diffusion_measurements.py \
-			$AnatomicalTractsFolder $AnatomicalTractsFolder/diffusion_measurements_anatomical_tracts.csv $FiberTractMeasurementsCLI
+			$AnatomicalTractsFolder $AnatomicalTractsFolder/diffusion_measurements_anatomical_tracts.csv "$FiberTractMeasurementsCLI"
 	else
 		echo " - diffusion measurements of anatomical tracts has been done."
 	fi
@@ -453,3 +453,4 @@ elif [ $CleanFiles == 2 ]; then
 fi
 
 exit
+ 

--- a/bin/wm_diffusion_measurements.py
+++ b/bin/wm_diffusion_measurements.py
@@ -36,7 +36,7 @@ def main():
         print("Error: Input directory", args.inputDirectory, "does not exist.")
         exit()
     
-    if not os.path.exists(args.Slicer):
+    if not os.path.exists(args.Slicer.split()[0]):
         print("Error: 3D Slicer", args.Slicer, "does not exist.")
         exit()
     

--- a/bin/wm_diffusion_measurements.py
+++ b/bin/wm_diffusion_measurements.py
@@ -36,7 +36,7 @@ def main():
         print("Error: Input directory", args.inputDirectory, "does not exist.")
         exit()
     
-    if not os.path.exists(args.Slicer.split()[0]):
+    if not os.path.exists(args.Slicer.split()[-1]):
         print("Error: 3D Slicer", args.Slicer, "does not exist.")
         exit()
     

--- a/bin/wm_diffusion_measurements.py
+++ b/bin/wm_diffusion_measurements.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import argparse
 import os
+from warnings import warn
 
 try:
     import whitematteranalysis as wma
@@ -36,9 +37,10 @@ def main():
         print("Error: Input directory", args.inputDirectory, "does not exist.")
         exit()
     
-    if not os.path.exists(args.Slicer.split()[-1]):
-        print("Error: 3D Slicer", args.Slicer, "does not exist.")
-        exit()
+    cli= args.Slicer.split()[-1]
+    if not os.path.exists(cli):
+        warn(f"{cli} module could not be found, program may fail.")
+    
     
     module_FTSM = args.Slicer + ' '
     


### PR DESCRIPTION
Slicer can be built standalone or downloaded. The current `wm_apply_ORG_atlas_to_subject.sh` script is compatible for a built Slicer that does not require various paths adjustment during execution. But it is not compatible with path adjusted Slicer commands. The incompatibility arises with the values accepted by `-s` and `-m` arguments.

* The `-s` accepted by `wm_apply_ORG_atlas_to_subject.sh` may not be just `Slicer`. For a shared `Slicer`, it can be `"AdditionalPaths=/path/to/SlicerDMRI /path/to/etc Slicer"`.

* Again, for a downloaded (not built) Slicer the `-m` argument can be `"Slicer --launch /path/to/Slicer-4.10/cli-modules/FiberTractMeasurements"`.

To support all such values of `-s` and `-m`, [`$SlicerPath`](https://github.com/SlicerDMRI/whitematteranalysis/blob/master/bin/wm_apply_ORG_atlas_to_subject.sh#L298) and [`$FiberTractMeasurementsCLI`](https://github.com/SlicerDMRI/whitematteranalysis/blob/master/bin/wm_apply_ORG_atlas_to_subject.sh#L393) must be enclosed in double-quotes.

For the same multiple choices available to `-s`, it is safest to check the existence of the last element of `-s` i.e. `args.Slicer.split()[-1]`.