### PR TITLE
STYLE: Upgrade python syntax to 3.6 and newer

### DIFF
--- a/bin/harden_transform_with_slicer.py
+++ b/bin/harden_transform_with_slicer.py
@@ -67,8 +67,8 @@ def main():
     if os.path.isfile(args.polydata):
         harden_transform(args.polydata, args.transform, args.inverse, args.outdir)
     elif os.path.isdir(args.polydata):
-        input_mask = "{0}/*.vtk".format(args.polydata)
-        input_mask2 = "{0}/*.vtp".format(args.polydata)
+        input_mask = f"{args.polydata}/*.vtk"
+        input_mask2 = f"{args.polydata}/*.vtp"
         input_pd_fnames = glob.glob(input_mask) + glob.glob(input_mask2)
         input_polydatas = sorted(input_pd_fnames)
     

--- a/bin/wm_append_clusters.py
+++ b/bin/wm_append_clusters.py
@@ -68,7 +68,7 @@ def main():
     
     elif args.tractMRML is not None:
         cluster_vtp_list = list()
-        f = open(args.tractMRML, 'r') 
+        f = open(args.tractMRML) 
         for line in f:
             idx = line.find('.vtp')
             if idx > 0:

--- a/bin/wm_append_clusters_to_anatomical_tracts.py
+++ b/bin/wm_append_clusters_to_anatomical_tracts.py
@@ -55,7 +55,7 @@ if not os.path.isdir(args.atlasDirectory):
 
 def list_mrml_files(input_dir):
     # Find input files
-    input_mask = "{0}/T*.mrml".format(input_dir)
+    input_mask = f"{input_dir}/T*.mrml"
     input_mrml_fnames = glob.glob(input_mask)
     return (input_mrml_fnames)
 
@@ -117,7 +117,7 @@ for tract in hemispheric_tracts:
 
     cluster_vtp_list_left = list()
     cluster_vtp_list_right = list()
-    f = open(mrml, 'r') 
+    f = open(mrml) 
     for line in f:
         idx = line.find('.vtp')
         if idx > 0:
@@ -154,7 +154,7 @@ for tract in commissural_tracts:
         exit()
 
     cluster_vtp_list_comm = list()
-    f = open(mrml, 'r') 
+    f = open(mrml) 
     for line in f:
         idx = line.find('.vtp')
         if idx > 0:
@@ -172,8 +172,8 @@ for tract in commissural_tracts:
 
 def list_cluster_files(input_dir):
     # Find input files
-    input_mask = "{0}/T_*.vtk".format(input_dir)
-    input_mask2 = "{0}/T_*.vtp".format(input_dir)
+    input_mask = f"{input_dir}/T_*.vtk"
+    input_mask2 = f"{input_dir}/T_*.vtp"
     input_pd_fnames = glob.glob(input_mask) + glob.glob(input_mask2)
     input_pd_fnames = sorted(input_pd_fnames)
     return(input_pd_fnames)

--- a/bin/wm_assess_cluster_location_by_hemisphere.py
+++ b/bin/wm_assess_cluster_location_by_hemisphere.py
@@ -55,8 +55,8 @@ def main():
     
     def list_cluster_files(input_dir):
         # Find input files
-        input_mask = "{0}/cluster_*.vtk".format(input_dir)
-        input_mask2 = "{0}/cluster_*.vtp".format(input_dir)
+        input_mask = f"{input_dir}/cluster_*.vtk"
+        input_mask2 = f"{input_dir}/cluster_*.vtp"
         input_pd_fnames = glob.glob(input_mask) + glob.glob(input_mask2)
         input_pd_fnames = sorted(input_pd_fnames)
         return(input_pd_fnames)

--- a/bin/wm_cluster_from_atlas.py
+++ b/bin/wm_cluster_from_atlas.py
@@ -251,7 +251,7 @@ def main():
         #pd_c = wma.filter.mask(output_polydata_s, mask, preserve_point_data=True, preserve_cell_data=True,verbose=False)
         pd_c = pd_c_list[c]
         # The clusters are stored starting with 1, not 0, for user friendliness.
-        fname_c = 'cluster_{0:05d}.vtp'.format(c+1)
+        fname_c = f'cluster_{c+1:05d}.vtp'
         # save the filename for writing into the MRML file
         fnames.append(fname_c)
         # prepend the output directory

--- a/bin/wm_cluster_remove_outliers.py
+++ b/bin/wm_cluster_remove_outliers.py
@@ -108,7 +108,7 @@ def main():
     # =======================================================================
     
     # Copy all MRML files to the new subject directory
-    input_mask = "{0}/clustered_tracts*.mrml".format(args.inputDirectory)
+    input_mask = f"{args.inputDirectory}/clustered_tracts*.mrml"
     mrml_files = sorted(glob.glob(input_mask))
     for fname_src in mrml_files:
         fname_base = os.path.basename(fname_src)
@@ -135,9 +135,9 @@ def main():
     ## atlas.brain_std_similarity = brain_std_sim
     
     # find clusters in subject and atlas input directories
-    input_mask = "{0}/cluster_*.vtp".format(args.atlasDirectory)
+    input_mask = f"{args.atlasDirectory}/cluster_*.vtp"
     atlas_clusters = sorted(glob.glob(input_mask))
-    input_mask = "{0}/cluster_*.vtp".format(args.inputDirectory)
+    input_mask = f"{args.inputDirectory}/cluster_*.vtp"
     subject_clusters = sorted(glob.glob(input_mask))
 
     # check these lists are the same length

--- a/bin/wm_download_anatomically_curated_atlas.py
+++ b/bin/wm_download_anatomically_curated_atlas.py
@@ -29,11 +29,11 @@ def main():
     def download_file(url, output_file):
     
         try:
-            print("* Downloading: {0}".format(url))
+            print(f"* Downloading: {url}")
             url_file = urllib.request.urlopen(url)
             meta = url_file.info()
             file_size = int(meta.get_all("Content-Length")[0])
-            print("File size: {0} MB".format(file_size/1024.0/1024.0))
+            print(f"File size: {file_size/1024.0/1024.0} MB")
     
             output = open(output_file, 'wb')
             file_size_dl = 0
@@ -45,7 +45,7 @@ def main():
                 file_size_dl += len(buffer)
                 output.write(buffer)
                 p = float(file_size_dl) / file_size
-                status = r"{0} bytes [{1:.2%}]".format(file_size_dl, p)
+                status = fr"{file_size_dl} bytes [{p:.2%}]"
                 status = status + chr(8)*(len(status)+1)
                 sys.stdout.write(status)
     

--- a/bin/wm_quality_control_after_clustering.py
+++ b/bin/wm_quality_control_after_clustering.py
@@ -60,8 +60,8 @@ def main():
     for sidx in range(0, num_of_subjects):
         sub = subject_list[sidx]
         sub_dir = os.path.join(args.inputDirectory, sub)
-        input_mask = "{0}/cluster_*.vtk".format(sub_dir)
-        input_mask2 = "{0}/cluster_*.vtp".format(sub_dir)
+        input_mask = f"{sub_dir}/cluster_*.vtk"
+        input_mask2 = f"{sub_dir}/cluster_*.vtp"
         cluster_polydatas = glob.glob(input_mask) + glob.glob(input_mask2)
         cluster_polydatas = sorted(cluster_polydatas)
         print("  ", sub, "has", len(cluster_polydatas), "clusters.")
@@ -82,8 +82,8 @@ def main():
         sub = subject_list[sidx]
         print("   loading", sub)
         sub_dir = os.path.join(args.inputDirectory, sub)
-        input_mask = "{0}/cluster_*.vtk".format(sub_dir)
-        input_mask2 = "{0}/cluster_*.vtp".format(sub_dir)
+        input_mask = f"{sub_dir}/cluster_*.vtk"
+        input_mask2 = f"{sub_dir}/cluster_*.vtp"
         cluster_polydatas = glob.glob(input_mask) + glob.glob(input_mask2)
         cluster_polydatas = sorted(cluster_polydatas)
         for cidx in range(0, num_of_clusters):

--- a/bin/wm_quality_control_tractography.py
+++ b/bin/wm_quality_control_tractography.py
@@ -244,7 +244,7 @@ def main():
         lengths = numpy.array(lengths)
         fibers_qc_file = open(fibers_qc_fname, 'a')
         outstr = str(subject_id) +  '\t'
-        outstr = outstr + '{0:.4f}'.format(step_size) + '\t'
+        outstr = outstr + f'{step_size:.4f}' + '\t'
         # total points in the dataset
         outstr = outstr + str(pd.GetNumberOfPoints()) + '\t'
         # mean fiber length

--- a/bin/wm_separate_clusters_by_hemisphere.py
+++ b/bin/wm_separate_clusters_by_hemisphere.py
@@ -65,8 +65,8 @@ def main():
     
     def list_cluster_files(input_dir):
         # Find input files
-        input_mask = "{0}/cluster_*.vtk".format(input_dir)
-        input_mask2 = "{0}/cluster_*.vtp".format(input_dir)
+        input_mask = f"{input_dir}/cluster_*.vtk"
+        input_mask2 = f"{input_dir}/cluster_*.vtp"
         input_pd_fnames = glob.glob(input_mask) + glob.glob(input_mask2)
         input_pd_fnames = sorted(input_pd_fnames)
         return(input_pd_fnames)

--- a/bin/wm_vtp2vtk.py
+++ b/bin/wm_vtp2vtk.py
@@ -61,7 +61,7 @@ def main():
     def list_vtp_files(input_dir):
         # Find input files (JUST vtp)
         #input_mask = "{0}/*.vtk".format(input_dir)
-        input_mask2 = "{0}/*.vtp".format(input_dir)
+        input_mask2 = f"{input_dir}/*.vtp"
         #input_pd_fnames = glob.glob(input_mask) + glob.glob(input_mask2)
         input_pd_fnames = glob.glob(input_mask2)
         input_pd_fnames = sorted(input_pd_fnames)

--- a/setup.py
+++ b/setup.py
@@ -36,17 +36,17 @@ class LazyCommandClass(dict):
     def __contains__(self, key):
         return (
             key == 'build_ext'
-            or super(LazyCommandClass, self).__contains__(key)
+            or super().__contains__(key)
         )
 
     def __setitem__(self, key, value):
         if key == 'build_ext':
             raise AssertionError("build_ext overridden!")
-        super(LazyCommandClass, self).__setitem__(key, value)
+        super().__setitem__(key, value)
 
     def __getitem__(self, key):
         if key != 'build_ext':
-            return super(LazyCommandClass, self).__getitem__(key)
+            return super().__getitem__(key)
 
         from Cython.Distutils import build_ext as cython_build_ext
 

--- a/utilities/wm_assess_cluster_location.py
+++ b/utilities/wm_assess_cluster_location.py
@@ -45,8 +45,8 @@ print("=====advanced_times_threshold====\n", args.advanced_times_threshold)
 
 def list_cluster_files(input_dir):
     # Find input files
-    input_mask = "{0}/cluster_*.vtk".format(input_dir)
-    input_mask2 = "{0}/cluster_*.vtp".format(input_dir)
+    input_mask = f"{input_dir}/cluster_*.vtk"
+    input_mask2 = f"{input_dir}/cluster_*.vtp"
     input_pd_fnames = glob.glob(input_mask) + glob.glob(input_mask2)
     input_pd_fnames = sorted(input_pd_fnames)
     return(input_pd_fnames)

--- a/utilities/wm_compute_FA_from_DWIs.py
+++ b/utilities/wm_compute_FA_from_DWIs.py
@@ -11,8 +11,8 @@ except:
 
 def list_nhdr_files(input_dir):
     # Find input files
-    input_mask = "{0}/*.nhdr".format(input_dir)
-    input_mask2 = "{0}/*.nrrd".format(input_dir)
+    input_mask = f"{input_dir}/*.nhdr"
+    input_mask2 = f"{input_dir}/*.nrrd"
     input_pd_fnames = glob.glob(input_mask) + glob.glob(input_mask2)
     input_pd_fnames = sorted(input_pd_fnames)
     return(input_pd_fnames)

--- a/utilities/wm_extract_cluster.py
+++ b/utilities/wm_extract_cluster.py
@@ -40,13 +40,13 @@ if not os.path.exists(outdir):
     os.makedirs(outdir)
 
 # cluster filename we want
-fname_c = 'cluster_{0:05d}.vtp'.format(args.cluster)
+fname_c = f'cluster_{args.cluster:05d}.vtp'
 # output MRML filename
-fname_mrml = 'all_clusters_{0:05d}.mrml'.format(args.cluster)
+fname_mrml = f'all_clusters_{args.cluster:05d}.mrml'
 fname_mrml = os.path.join(outdir, fname_mrml)
 
 # Find input directories that may contain clusters
-input_mask = "{0}/*".format(args.inputDirectory)
+input_mask = f"{args.inputDirectory}/*"
 input_directories = sorted(glob.glob(input_mask))
 
 # Loop over inputs and try to find clusters

--- a/utilities/wm_extract_clusters_by_endpoints.py
+++ b/utilities/wm_extract_clusters_by_endpoints.py
@@ -133,8 +133,8 @@ for sub_id, subject_measured, region_index in zip(subject_id_list, measurement_l
     percent_str = sub_id + '(' + str(subject_measured.measurement_header[region_index]) + ')'
     title_str = ("{:<"+str(len(sub_id)+len(region)+2)+"}").format('Percentage:')
     for p in percentage_range:
-        percent_str = percent_str + ', ' + "{:<4}".format(str(sum(subject_percentage_distribution > p)))
-        title_str = title_str + ', ' + "{:<4}".format(str(p))
+        percent_str = percent_str + ', ' + f"{str(sum(subject_percentage_distribution > p)):<4}"
+        title_str = title_str + ', ' + f"{str(p):<4}"
 
     if not print_title:
         print(title_str)

--- a/utilities/wm_flatten_length_distribution.py
+++ b/utilities/wm_flatten_length_distribution.py
@@ -103,8 +103,8 @@ print("==========================")
 # =======================================================================
 
 # Loop over input DWIs
-inputMask1 = "{0}/*.vtk".format(args.inputDirectory)
-inputMask2 = "{0}/*.vtp".format(args.inputDirectory)
+inputMask1 = f"{args.inputDirectory}/*.vtk"
+inputMask2 = f"{args.inputDirectory}/*.vtp"
 
 inputPolyDatas = glob.glob(inputMask1) + glob.glob(inputMask2)
 

--- a/utilities/wm_measure_all_clusters.py
+++ b/utilities/wm_measure_all_clusters.py
@@ -107,7 +107,7 @@ f = open(args.outputFile, 'w')
 for row in output_rows:
     outstr = ''
     for item in row:
-        if outstr is not '':
+        if outstr != '':
             outstr = outstr + '\t'
         outstr = outstr + str(item)
     outstr = outstr + '\n'

--- a/utilities/wm_measure_endpoint_overlap.py
+++ b/utilities/wm_measure_endpoint_overlap.py
@@ -75,8 +75,8 @@ print("<wm_endpoint_analysis> found", len(tract_dir_list), "subjects.")
 
 def list_label_map_files(input_dir):
     # Find input files
-    input_mask = "{0}/*.nrrd".format(input_dir)
-    input_mask2 = "{0}/*.nhdr".format(input_dir)
+    input_mask = f"{input_dir}/*.nrrd"
+    input_mask2 = f"{input_dir}/*.nhdr"
     input_fnames = glob.glob(input_mask) + glob.glob(input_mask2)
     input_fnames = sorted(input_fnames)
     return(input_fnames)
@@ -107,7 +107,7 @@ Parallel(n_jobs=number_of_jobs, verbose=1)(
 
 def list_txt_files(input_dir):
     # Find input files
-    input_mask = "{0}/*.txt".format(input_dir)
+    input_mask = f"{input_dir}/*.txt"
     input_fnames = glob.glob(input_mask)
     input_fnames = sorted(input_fnames)
     

--- a/utilities/wm_statistics.py
+++ b/utilities/wm_statistics.py
@@ -369,7 +369,7 @@ if atlas_directory:
     fname = './test_'+measurement+'.mrml'
     print("Saving MRML visualization:", fname)
     # find clusters in subject and atlas input directories
-    input_mask = "{0}/cluster_*.vtp".format(atlas_directory)
+    input_mask = f"{atlas_directory}/cluster_*.vtp"
     atlas_clusters = sorted(glob.glob(input_mask))
     number_of_files = len(atlas_clusters)
     if number_of_files == number_of_clusters:

--- a/whitematteranalysis/cluster.py
+++ b/whitematteranalysis/cluster.py
@@ -174,8 +174,8 @@ def nearPSD(A,epsilon=0):
    val = numpy.matrix(numpy.maximum(eigval,epsilon))
    vec = numpy.matrix(eigvec)
    T = 1/(numpy.multiply(vec,vec) * val.T)
-   T = numpy.matrix(numpy.sqrt(numpy.diag(numpy.array(T).reshape((n)) )))
-   B = T * vec * numpy.diag(numpy.array(numpy.sqrt(val)).reshape((n)))
+   T = numpy.matrix(numpy.sqrt(numpy.diag(numpy.array(T).reshape(n) )))
+   B = T * vec * numpy.diag(numpy.array(numpy.sqrt(val)).reshape(n))
    out = B*B.T
    return(numpy.asarray(out))
    
@@ -1028,7 +1028,7 @@ def output_and_quality_control_cluster_atlas(atlas, output_polydata_s, subject_f
         farray.convert_from_polydata(pd_c, points_per_fiber=50)
         filter.add_point_data_array(pd_c, farray.fiber_hemisphere, "Hemisphere")
         # The clusters are stored starting with 1, not 0, for user friendliness.
-        fname_c = 'cluster_{0:05d}.vtp'.format(c+1)
+        fname_c = f'cluster_{c+1:05d}.vtp'
         # save the filename for writing into the MRML file
         fnames.append(fname_c)
         # prepend the output directory

--- a/whitematteranalysis/io.py
+++ b/whitematteranalysis/io.py
@@ -60,15 +60,15 @@ def read_polydata(filename):
 
 def list_vtk_files(input_dir):
     # Find input files
-    input_mask = "{0}/*.vtk".format(input_dir)
-    input_mask2 = "{0}/*.vtp".format(input_dir)
+    input_mask = f"{input_dir}/*.vtk"
+    input_mask2 = f"{input_dir}/*.vtp"
     input_pd_fnames = glob.glob(input_mask) + glob.glob(input_mask2)
     input_pd_fnames = sorted(input_pd_fnames)
     return(input_pd_fnames)
 
 def list_transform_files(input_dir):
     # Find input files
-    input_mask = "{0}/*.tfm".format(input_dir)
+    input_mask = f"{input_dir}/*.tfm"
     input_tf_fnames = glob.glob(input_mask)
     input_tf_fnames = sorted(input_tf_fnames)
     return (input_tf_fnames)
@@ -165,7 +165,7 @@ def transform_polydata_from_disk(in_filename, transform_filename, out_filename):
         print(coeffs)
         print(transform)
     else:
-        f = open(transform_filename, 'r')
+        f = open(transform_filename)
         transform = vtk.vtkTransform()
         matrix = vtk.vtkMatrix4x4()
         for i in range(0,4):
@@ -423,7 +423,7 @@ def write_transforms_to_itk_format(transform_list, outdir, subject_ids=None):
             if subject_ids is not None:
                 fname = 'vtk_txform_' + str(subject_ids[idx]) + '.xfm'
             else:
-                fname = 'vtk_txform_{0:05d}.xfm'.format(idx)
+                fname = f'vtk_txform_{idx:05d}.xfm'
             writer.SetFileName(os.path.join(outdir, fname))
             writer.Write()
 
@@ -431,7 +431,7 @@ def write_transforms_to_itk_format(transform_list, outdir, subject_ids=None):
         if subject_ids is not None:
             fname = 'itk_txform_' + str(subject_ids[idx]) + '.tfm'
         else:
-            fname = 'itk_txform_{0:05d}.tfm'.format(idx)
+            fname = f'itk_txform_{idx:05d}.tfm'
         fname = os.path.join(outdir, fname)
         tx_fnames.append(fname)
 
@@ -566,18 +566,18 @@ def write_transforms_to_itk_format(transform_list, outdir, subject_ids=None):
             # all grid nodes."
             for block in [0, 1, 2]:
                 for diff in displacements_LPS:
-                    f.write('{0} '.format(diff[block]))
+                    f.write(f'{diff[block]} ')
 
             #FixedParameters: size size size origin origin origin origin spacing spacing spacing (then direction cosines: 1 0 0 0 1 0 0 0 1)
             f.write('\nFixedParameters:')
             #f.write(' {0} {0} {0}'.format(2*sz+1))
-            f.write(' {0}'.format(grid_size[0]))
-            f.write(' {0}'.format(grid_size[1]))
-            f.write(' {0}'.format(grid_size[2]))
+            f.write(f' {grid_size[0]}')
+            f.write(f' {grid_size[1]}')
+            f.write(f' {grid_size[2]}')
 
-            f.write(' {0}'.format(origin[0]))
-            f.write(' {0}'.format(origin[1]))
-            f.write(' {0}'.format(origin[2]))
+            f.write(f' {origin[0]}')
+            f.write(f' {origin[1]}')
+            f.write(f' {origin[2]}')
             f.write(' {0} {0} {0}'.format(grid_spacing))
             f.write(' 1 0 0 0 1 0 0 0 1\n')
 
@@ -610,9 +610,9 @@ def write_transforms_to_itk_format(transform_list, outdir, subject_ids=None):
             f.write('Transform: AffineTransform_double_3_3\n')
             f.write('Parameters: ')
             for el in three_by_three:
-                f.write('{0} '.format(el))
+                f.write(f'{el} ')
             for el in translation:
-                f.write('{0} '.format(el))
+                f.write(f'{el} ')
             f.write('\nFixedParameters: 0 0 0\n')
             f.close()
 
@@ -736,28 +736,28 @@ class LateralityResults:
 
         # input LI and other data values using pickle
         fname = os.path.join(dirname, 'pickle_laterality_index.txt')
-        fid = open(fname, 'r')
+        fid = open(fname)
         self.laterality_index = pickle.load(fid)
         fid.close()
 
         fname = os.path.join(dirname, 'pickle_left_hem_similarity.txt')
-        fid = open(fname, 'r')
+        fid = open(fname)
         self.left_hem_similarity = pickle.load(fid)
         fid.close()
         fname = os.path.join(dirname, 'pickle_right_hem_similarity.txt')
-        fid = open(fname, 'r')
+        fid = open(fname)
         self.right_hem_similarity = pickle.load(fid)
         fid.close()
         fname = os.path.join(dirname, 'pickle_hemisphere.txt')
-        fid = open(fname, 'r')
+        fid = open(fname)
         self.hemisphere = pickle.load(fid)
         fid.close()
 
         if readdist:
-            fid = open(os.path.join(dirname, 'pickle_right_hem_distance.txt'), 'r')
+            fid = open(os.path.join(dirname, 'pickle_right_hem_distance.txt'))
             self.right_hem_distance = pickle.load(fid)
             fid.close()
-            fid = open(os.path.join(dirname, 'pickle_left_hem_distance.txt'), 'r')
+            fid = open(os.path.join(dirname, 'pickle_left_hem_distance.txt'))
             self.left_hem_distance = pickle.load(fid)
             fid.close()
 

--- a/whitematteranalysis/render.py
+++ b/whitematteranalysis/render.py
@@ -255,7 +255,7 @@ class RenderPolyData:
         else:
             lut.SetRange(scalar_range)
 
-        if opacity is not 1:
+        if opacity != 1:
             actor.GetProperty().SetOpacity(opacity)
 
         if depth_peeling is not False:

--- a/whitematteranalysis/tract_measurement.py
+++ b/whitematteranalysis/tract_measurement.py
@@ -43,7 +43,7 @@ class TractMeasurement:
             raise AssertionError
 
         txt_matrix = []
-        with open(self.measurement_file, 'r') as txtfile:
+        with open(self.measurement_file) as txtfile:
             reader = csv.reader(txtfile, delimiter=separator_char, skipinitialspace=True,  quoting=csv.QUOTE_NONE)
             for row in reader:
                 row = list(map(str.strip, row))
@@ -104,8 +104,8 @@ def load_measurement_in_folder(measurement_folder, hierarchy = 'Column', separat
     """
 
     # txt of csv files will be handled
-    input_mask = "{0}/*.txt".format(measurement_folder)
-    input_mask2 = "{0}/*.csv".format(measurement_folder)
+    input_mask = f"{measurement_folder}/*.txt"
+    input_mask2 = f"{measurement_folder}/*.csv"
 
     measurement_files = glob.glob(input_mask) + glob.glob(input_mask2)
     measurement_files = sorted(measurement_files)


### PR DESCRIPTION
This PR uses [`pyupgrade`](https://github.com/asottile/pyupgrade) to automatically upgrade python syntax to newer versions. The script listed below was run for Python 3.6+ syntax with changes committed.

## Using pyupgrade

- Install: `Python -m pip install pyupgrade`
- Running:
  - On 1 file: `Python -m pyupgrade --py36-plus MyPythonFile.py`
  - On multiple files: Here is my pyupgrade-script.py written to automate running pyupgrade across all python files in the repo. It was run by `Python pyupgrade-script.py`.
```python
# pyupgrade-script.py
import os
import subprocess

search_directory = "C:/Users/JamesButler/Documents/GitHub/whitematteranalysis"
for root, _, files in os.walk(search_directory):
    for file_item in files:
        file_path = os.path.join(root, file_item)
        if os.path.isfile(file_path) and file_path.endswith(".py"):
            subprocess.call(["Python", "-m", "pyupgrade", "--py36-plus", file_path])
```