### PR TITLE
BUG: fix transform hardening for Slicer

### DIFF
--- a/bin/harden_transform_with_slicer.py
+++ b/bin/harden_transform_with_slicer.py
@@ -13,7 +13,7 @@ def harden_transform(polydata, transform, inverse, outdir):
     if os.path.exists(output_name):
         return
     
-    check_load, polydata_node = slicer.util.loadModel(str(polydata), 1)
+    check_load, polydata_node = slicer.util.loadFiberBundle(str(polydata), 1)
     if not check_load:
         print('Could not load polydata file:', polydata)
         return


### PR DESCRIPTION
As of the commit linked below, Slicer assumes that models with no explicitly declared space should be LPS.  For FiberBundles, SlicerDMRI explicitly defines the contents to be RAS if the space is not declared, for backwards compatibility.

The change in the commit uses the `loadFiberBundle` method to explicitly use the SlicerDMRI reader so that the tracts are correctly interpreted.

The `loadFiberBundle` method existed in 4.10.2 (actually since 2011) so no current users should have any problem with this change.

https://github.com/Slicer/Slicer/commit/6036edbc4b67712822ccb4ee89139cab1cbce3f2