### PR TITLE
ENH: Add GitHub actions build, test workflow file for CI

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -1,0 +1,73 @@
+name: test, package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      # max-parallel: 6
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.8']
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    # - name: Cache pip
+    #   uses: actions/cache@v2
+    #   id: cache
+    #   with:
+    #     path: ${{ env.pythonLocation }}
+    #     # Look to see if there is a cache hit for the corresponding requirements files
+    #     key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/*') }}
+    #     restore-keys: |
+    #       ${{ env.pythonLocation }}-
+
+    - name: Install dependencies
+      # if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        python -m pip install --upgrade --user pip setuptools pytest-cov
+        python --version
+        pip --version
+        pip list
+
+    - name: Run tests
+      run: |
+        # tox --sitepackages
+        python setup.py install
+        python -c 'import whitematteranalysis'
+        # coverage run --source whitematteranalysis -m pytest whitematteranalysis -o junit_family=xunit2 -v --doctest-modules --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
+
+    - name: Upload pytest test results
+      uses: actions/upload-artifact@master
+      with:
+        name: pytest-results-${{ runner.os }}-${{ matrix.python-version }}
+        path: junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
+      # Use always() to always run this step to publish test results when there are test failures
+      if: always()
+
+    - name: Package Setup
+    # - name: Run tests with tox
+      run: |
+        # pip install build
+        # check-manifest
+        python setup.py install
+        # twine check dist/
+        # tox --sitepackages
+        # python -m tox
+
+    # - name: Statistics
+      # if: success()
+      # run: |
+      #   coverage report

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 whitematteranalysis
 ===================
 
+[![test, package](https://github.com/SlicerDMRI/whitematteranalysis/actions/workflows/test_package.yaml/badge.svg?branch=master)](https://github.com/SlicerDMRI/whitematteranalysis/actions/workflows/test_package.yaml?query=branch%3Amaster)
+
 # Synopsis
 
 WhiteMatterAnalysis (WMA) provides fiber clustering and tractography analysis tools.

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ class LazyCommandClass(dict):
 ########################################################################
 
 
-setup_requires = ['cython', 'numpy']
+setup_requires = ['cython==0.29.*', 'numpy==1.20.*']
 setup(
     name='WhiteMatterAnalysis',
     version='0.3.0',
@@ -89,8 +89,8 @@ setup(
     long_description=open('README.md').read(),
   
     setup_requires = setup_requires,
-    install_requires = setup_requires + ['setuptools', 'scipy', 'vtk',
-                        'joblib', 'statsmodels', 'xlrd', 'matplotlib', 'nibabel'],
+    install_requires = setup_requires + ['setuptools==44.0.*', 'scipy==1.4.*', 'vtk==9.1.*',
+                        'joblib==1.1.*', 'statsmodels==0.10.*', 'xlrd', 'matplotlib==3.6.*', 'nibabel==3.0.*'],
     
     cmdclass=LazyCommandClass(),
 


### PR DESCRIPTION
Add GitHub actions build, test workflow file for CI.

Pin the dependencies in the setup file.

Add the corresponding status badge to the `README` file.
