### PR TITLE
DOC: Fix miscellaneous typos and grammar across files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ WhiteMatterAnalysis (WMA) provides fiber clustering and tractography analysis to
 # WMA Installation and Usage
 ## 1. Install Python 3:
 
-Miniconda is a nice option becuase it includes pip, setuptools, and all library dependencies (such as VTK and scipy).
+Miniconda is a nice option because it includes pip, setuptools, and all library dependencies (such as VTK and scipy).
 
   - Download and install Miniconda from https://conda.io/miniconda.html
 
@@ -19,7 +19,7 @@ The following command will use pip to install whitematteranalysis from this sour
       pip install git+https://github.com/SlicerDMRI/whitematteranalysis.git
 
 
-  (Note: On MacOS, to able to use pip, X-code needs to be installed using `xcode-select --install`.)
+  (Note: On macOS, to be able to use pip, X-code needs to be installed using `xcode-select --install`.)
 
 Run `wm_quality_control_tractography.py --help` to test if the installation is successful.
 
@@ -29,7 +29,7 @@ Run `wm_quality_control_tractography.py --help` to test if the installation is s
 
     ```bash wm_apply_ORG_atlas_to_subject.sh -i input_tractography.vtk -o output_dir -a path_to_atlas/ORG-Atlases-v1.x -s /Applications/Slicer5.2.2.app/Contents/MacOS/Slicer -d 1 -m /Applications/Slicer5.2.2.app/Contents/Extensions-31382/SlicerDMRI/lib/Slicer-5.2/cli-modules/FiberTractMeasurements```
 
-* A step-by-step tutorial to explain the detailed computional process within the pipeline is provided [here](https://github.com/SlicerDMRI/whitematteranalysis/blob/master/doc/subject-specific-tractography-parcellation.md).
+* A step-by-step tutorial to explain the detailed computational process within the pipeline is provided [here](https://github.com/SlicerDMRI/whitematteranalysis/blob/master/doc/subject-specific-tractography-parcellation.md).
 
 # References
 

--- a/bin/wm_apply_ORG_atlas_to_subject.sh
+++ b/bin/wm_apply_ORG_atlas_to_subject.sh
@@ -9,28 +9,28 @@ Compulsory arguments:
      -o:  Output directory to save all fiber clustering outputs.
      -a:  Path to the ORG atlas (the anatomically curated atlas ORG-800FC-100HCP), within which there should be 
           two folders named: ORG-RegAtlas-100HCP and ORG-800FC-100HCP 
-     -s:  Path to 3D Slicer, e.g., under MacOS, it is /Applications/Slicer.app/Contents/MacOS/Slicer
+     -s:  Path to 3D Slicer, e.g., under macOS, it is /Applications/Slicer.app/Contents/MacOS/Slicer
 Optional arguments:
      -r:  whole brain tractography registration mode (default = 'rig')
-            rig: rigid_affine_fast : this enables a rough tractography registraion. This mode in general 
+            rig: rigid_affine_fast : this enables a rough tractography registration. This mode in general
                                    applicable to tractography data generated from different dMRI 
                                    acquisitions and different populations (such as babies)
             nonrig: affine + nonrigid (2 stages) : this enables nonrigid deformations of the fibers. This mode
-                                              needs the input tractography to be similar to the atals tractography, 
-                                              e.g. two-tensor UKF tractography + HCP dMRI acquisiton. 
-     -n:  Number of threads (default = 1). If mutiple cores are available, recommended setting is 4. 
+                                              needs the input tractography to be similar to the atlas tractography,
+                                              e.g. two-tensor UKF tractography + HCP dMRI acquisition.
+     -n:  Number of threads (default = 1). If multiple cores are available, recommended setting is 4.
           Increasing the number of threads does not speed up too much, but it requires more computational resources.) 
      -x:  If the job is being run in an environment without a X client, a virtual X server environment is needed (for 
            transforming fiber clusters in the atlas space back to the tractography space using 3D Slicer). Use value 1 
            to indicate the usage of a virtual X server (default 0).
      -d: Export diffusion tensor measurements for each fiber cluster (or fiber tract). Note that diffusion tensor 
          (or other diffusion measurements) must be stored in the input VTK file. If this is specified, -m needs to be provided.
-     -m: Path to the FiberTractMeasurements module in SlicerDMRI. For example, in 3D Slicer 4.11 stable release under MacOS, 
+     -m: Path to the FiberTractMeasurements module in SlicerDMRI. For example, in 3D Slicer 4.11 stable release under macOS,
          the CLI module path is:
            /Applications/Slicer.app/Contents/Extensions-28264/SlicerDMRI/lib/Slicer-4.11/cli-modules/FiberTractMeasurements
      -c Clean the internal temporary files (default : 0)
             0 : keep all files
-            1 : mininal removal : initial bilateral clusters, transformed bilateral clusters
+            1 : minimal removal : initial bilateral clusters, transformed bilateral clusters
             2 : maximal removal : remove registration temp files, initial bilateral clusters, outlier removed bilateral clusters, transformed bilateral clusters
 
 Example:
@@ -51,8 +51,8 @@ function reportMappingParameters {
  Input tractography:          $InputTractography
  Output directory:            $OutputDir
  ORG atlas folder:            $AtlasBaseFolder
- 3D Slier:                    $SlicerPath
- Registraion mode:            $RegMode
+ 3D Slicer:                   $SlicerPath
+ Registration mode:           $RegMode
  Number of threads:           $NumThreads
  virtual X server:            $VX
  Export dMRI measures:        $DiffMeasure
@@ -174,7 +174,7 @@ else
 	numfiles=${#numfiles[@]}
 	if [ $numfiles -gt 1 ] ;then
 		echo ""
-		echo "** Anantomical tracts ($numfiles tracts) are detected in the output folder. Manually remove all files to rerun."
+		echo "** Anatomical tracts ($numfiles tracts) are detected in the output folder. Manually remove all files to rerun."
 		echo ""
 		#exit
 	fi
@@ -193,7 +193,7 @@ echo " - fiber clustering atlas:" $FCAtlasFolder
 echo ""
 
 
-echo "<wm_apply_ORG_atlas_to_subject> Tractography registraion with mode [" $RegMode "]"
+echo "<wm_apply_ORG_atlas_to_subject> Tractography registration with mode [" $RegMode "]"
 RegistrationFolder=$OutputCaseFolder/TractRegistration
 if [ "$RegMode" == "rig" ]; then
 	RegTractography=$RegistrationFolder/${caseID}/output_tractography/${caseID}_reg.vtk
@@ -441,7 +441,7 @@ fi
 echo ""
 
 if [ $CleanFiles == 1 ]; then
-	echo "<wm_apply_ORG_atlas_to_subject> Clean files using mininal removal."
+	echo "<wm_apply_ORG_atlas_to_subject> Clean files using minimal removal."
 	rm -rf $OutputCaseFolder/FiberClustering/InitialClusters
 	rm -rf $OutputCaseFolder/FiberClustering/TransformedClusters
 

--- a/bin/wm_assess_cluster_location_by_hemisphere.py
+++ b/bin/wm_assess_cluster_location_by_hemisphere.py
@@ -43,12 +43,12 @@ def main():
              'Default number is 0.6, where a higher number will tend to label fewer fibers as hemispheric and more fibers as commissural (not strictly in one hemisphere or the other), '
              'while a lower number will be stricter about what is classified as commissural. '
              'This parameter is not applicable if -clusterLocationFile was provided. '
-             'Note: performing hemisphere separation uinsg -pthresh needs the input clusters are in the ATLAS space.')
+             'Note: performing hemisphere separation using -pthresh needs the input clusters be in the ATLAS space.')
     parser.add_argument(
         '-clusterLocationFile', action="store", dest="clusterLocationFile",
         help='A csv file defining the location of each cluster, i.e., hemispheric or commissural. '
              'The hemispherePercentThreshold will be varied across the clusters if their locations are already known.'
-             'Note: performing hemisphere separation uinsg -clusterLocationFile needs the input clusters are in the ATLAS space.')
+             'Note: performing hemisphere separation using -clusterLocationFile needs the input clusters be in the ATLAS space.')
     parser.add_argument(
         '-outputDirectory',
         help='If this is given, separated clusters will be output under this folder. The output directory will be created if it does not exist.')

--- a/bin/wm_average_tract_measures.py
+++ b/bin/wm_average_tract_measures.py
@@ -11,7 +11,7 @@ import re
 # Parse arguments
 #-----------------
 parser = argparse.ArgumentParser(
-    description="Compute averged statistics of the anatomical tracts. For diffusion measure with multiple statistics, only the Mean will be outputted.",
+    description="Compute averaged statistics of the anatomical tracts. For diffusion measure with multiple statistics, only the Mean will be outputted.",
     epilog="Written by Fan Zhang, fzhang@bwh.harvard.edu.")
 parser.add_argument(
     'inputmeasure',
@@ -37,7 +37,7 @@ fields = numpy.array(fields)
 
 print(fields)
 
-print('All avaiable tracts:')
+print('All available tracts:')
 all_tracts = [f_name.replace('.Num_Points', '') for f_name in fields if f_name.endswith('.Num_Points')]
 print('N = ', str(len(all_tracts)), ':')
 print(all_tracts)

--- a/bin/wm_cluster_volumetric_measurements.py
+++ b/bin/wm_cluster_volumetric_measurements.py
@@ -32,7 +32,7 @@ def main():
     
     parser.add_argument(
         'inputVolumetricMap',
-        help='Path to input volumetric map, e.g. an FA image. Note: this input image needs to be a nifti (nii or nii.gz) file. To read and writ this format, NiBabel package is needed, by runing: pip install nibabel ')
+        help='Path to input volumetric map, e.g. an FA image. Note: this input image needs to be a nifti (nii or nii.gz) file. To read and write this format, NiBabel package is needed, by running: pip install nibabel ')
     
     parser.add_argument(
         'outputDirectory',
@@ -59,7 +59,7 @@ def main():
     
     inputvol = os.path.abspath(args.inputVolumetricMap)
     if not os.path.exists(inputvol):
-        print("Error: Input volumetri map", inputvol, "does not exist.")
+        print("Error: Input volumetric map", inputvol, "does not exist.")
         exit()
     
     outdir = os.path.abspath(args.outputDirectory)

--- a/bin/wm_diffusion_measurements.py
+++ b/bin/wm_diffusion_measurements.py
@@ -23,7 +23,7 @@ def main():
         help="Show program's version number and exit")
     parser.add_argument(
         'inputDirectory',
-        help='Directory of fiber clustering results obtained by <wm_cluster_from_altas.py> of multiple subjects. Make sure only the fiber clustering results are stored in this folder, making one subdirectory corresponding to one subject.')
+        help='Directory of fiber clustering results obtained by <wm_cluster_from_atlas.py> of multiple subjects. Make sure only the fiber clustering results are stored in this folder, making one subdirectory corresponding to one subject.')
     parser.add_argument(
         'outputCSV',
         help='Directory of output CSV files of fiber scalar measurement (computed using Slicer FiberTractMeasurements module).')

--- a/bin/wm_quality_control_after_clustering.py
+++ b/bin/wm_quality_control_after_clustering.py
@@ -34,7 +34,7 @@ def main():
         help="Show program's version number and exit")
     parser.add_argument(
         'inputDirectory',
-        help='Directory of fiber clustering results obtained by <wm_cluster_from_altas.py> of multiple subjects. Make sure only the fiber clustering results are stored in this folder, making one subdirectory corresponding to one subject.')
+        help='Directory of fiber clustering results obtained by <wm_cluster_from_atlas.py> of multiple subjects. Make sure only the fiber clustering results are stored in this folder, making one subdirectory corresponding to one subject.')
     parser.add_argument(
         'outputDirectory',
         help='Quality control information will be stored in the output directory, which will be created if it does not exist.')

--- a/bin/wm_register_multisubject_faster.py
+++ b/bin/wm_register_multisubject_faster.py
@@ -209,7 +209,7 @@ def main():
         initial_step_per_scale = [5, 4, 3, 2, 1.5]
         final_step_per_scale = [3, 3, 2, 1, 1]
         # use only very local information (small sigma)
-        # sigma 1.25 is apparently not useful: stick with a minumum of 2mm
+        # sigma 1.25 is apparently not useful: stick with a minimum of 2mm
         sigma_per_scale = [5, 3, 2, 2, 2]
         # how many times to repeat the process at each scale
         iterations_per_scale = [10, 10, 8, 5, 2]
@@ -241,7 +241,7 @@ def main():
         initial_step_per_scale = [5, 4, 3, 2, 1.5]
         final_step_per_scale = [3, 3, 2, 1, 1]
         # use only very local information (small sigma)
-        # sigma 1.25 is apparently not useful: stick with a minumum of 2mm
+        # sigma 1.25 is apparently not useful: stick with a minimum of 2mm
         sigma_per_scale = [5, 3, 2, 2, 2]
         # how many times to repeat the process at each scale
         iterations_per_scale = [10, 10, 8, 5, 2]

--- a/bin/wm_register_to_atlas_new.py
+++ b/bin/wm_register_to_atlas_new.py
@@ -197,7 +197,7 @@ def main():
         initial_step_per_scale = [5, 4, 3, 2, 1.5]
         final_step_per_scale = [3, 3, 2, 1, 1]
         # use only very local information (small sigma)
-        # sigma 1.25 is apparently not useful: stick with a minumum of 2mm
+        # sigma 1.25 is apparently not useful: stick with a minimum of 2mm
         sigma_per_scale = [5, 3, 2, 2, 2]
         # how many times to repeat the process at each scale
         iterations_per_scale = [10, 10, 8, 5, 2]
@@ -231,7 +231,7 @@ def main():
         initial_step_per_scale = [5, 4, 3, 2, 1.5, 1.5, 1.5]
         final_step_per_scale = [3, 3, 2, 1, 1, 1, 1]
         # use only very local information (small sigma)
-        # sigma 1.25 is apparently not useful: stick with a minumum of 2mm
+        # sigma 1.25 is apparently not useful: stick with a minimum of 2mm
         sigma_per_scale = [5, 3, 2, 2, 2, 2, 2]
         # how many times to repeat the process at each scale
         iterations_per_scale = [10, 10, 8, 5, 4, 3, 2]

--- a/bin/wm_separate_clusters_by_hemisphere.py
+++ b/bin/wm_separate_clusters_by_hemisphere.py
@@ -153,12 +153,12 @@ def main():
            
          # If HemisphereLocataion is not defined in the input vtk file, the location of each fiber in the cluster is decided.
         if not flag_location:
-            print("Error:", fname, "has no hemisphere location infromation")
+            print("Error:", fname, "has no hemisphere location information")
             exit()
     
         # for sanity check 
         if len(numpy.where(mask_location ==0)[0]) > 1:
-            print("Error: Not all fibers in", fname, "is labeled with hemisphere location infromation.")
+            print("Error: Not all fibers in", fname, "is labeled with hemisphere location information.")
             exit()
     
         # output separated clusters

--- a/doc/subject-specific-tractography-parcellation.md
+++ b/doc/subject-specific-tractography-parcellation.md
@@ -18,7 +18,7 @@ On this page, we provide step-by-step instructions to guide a user to run the en
     
 ## 2. Download tutorial data
    - Download the tutorial data package ([WMA_tutorial_data.zip](https://www.dropbox.com/s/beju3c0g9jqw5uj/WMA_tutorial_data.zip?dl=0), ~2.5GB)
-   - Decompress the downlaoded zip file to *Desktop* of your computer
+   - Decompress the downloaded zip file to *Desktop* of your computer
    - Files in the decompressed data folder should be organized as below, including:
      - The O'Donnell Research Group (ORG) white matter atlas (“_ORG-Atlases-1.1.1_”)
         > The ORG atlas contains an 800-cluster parcellation of the entire white matter and an anatomical fiber tract parcellation (see [here](http://dmri.slicer.org/atlases) for more details).
@@ -30,11 +30,11 @@ On this page, we provide step-by-step instructions to guide a user to run the en
 
 ## 3. Prepare terminal environment to run related commands
    - Open terminal from the operating system that you are using
-      - MacOS: Open */Applications/Utilities/Terminal.app*
+      - macOS: Open */Applications/Utilities/Terminal.app*
       - Linux (e.g. Red Hat): Open */Applications/System Tools/Terminal*
       - Windows (e.g. Windows 10): TBD
     
-        > **_Note_**: This tutorial is based on MacOS. All commands listed can be directly used on Linux. For Windows, users need to change the commands by using Windows system separator “\”.
+        > **_Note_**: This tutorial is based on macOS. All commands listed can be directly used on Linux. For Windows, users need to change the commands by using Windows system separator “\”.
 
    - Go to the tutorial data folder from terminal by typing the following command. (Make sure that you have decompressed the tutorial data to your desktop)
     
@@ -74,7 +74,7 @@ This step performs QC of the input tractography data (“_example-UKF-data.vtk_�
      wm_quality_control_tract_overlap.py ./ORG-Atlases-1.1.1/ORG-800FC-100HCP/atlas.vtp ./example-UKF-data.vtk ./QC/InputTractOverlap/
      ```
         
-      - A new “_QC/InputTractOverlap_” folder is generated, including multiple JPG files to enable visualization of tract overlap from different views. Open one of them, e.g., “_view_left_tract_overlap.jpg_”, where the different colors represent the different tractography data. The yellow tract is from the altas, and the red tract shows the input tractography. This image shows that the two tractography files are in the same coordinate system, but they are not aligned together.
+      - A new “_QC/InputTractOverlap_” folder is generated, including multiple JPG files to enable visualization of tract overlap from different views. Open one of them, e.g., “_view_left_tract_overlap.jpg_”, where the different colors represent the different tractography data. The yellow tract is from the atlas, and the red tract shows the input tractography. This image shows that the two tractography files are in the same coordinate system, but they are not aligned together.
        
         ![test image](tutorial-pics/fig_qc_input_overlap.jpg)
         
@@ -104,13 +104,13 @@ This steps registers the input tractography data to the ORG atlas tractography d
      wm_quality_control_tract_overlap.py ./ORG-Atlases-1.1.1/ORG-800FC-100HCP/atlas.vtp ./TractRegistration/example-UKF-data/output_tractography/example-UKF-data_reg.vtk ./QC/RegTractOverlap/
      ```
    
-      - A new folder “_QC/RegTractOverlap_” is generated, including multiple JPG files to enable visualization of tract overlap from different views. Open one of them, e.g., “_view_left_tract_overlap.jpg_”, where the different colors represent the different tractography data (as displayed below). The yellow tract is from the altas, and the red tract shows the input tractography. This image shows the input tractography data has been registered into the atlas space (overlapping well with the atlas tractography data; see above for the tract overlap before registration).
+      - A new folder “_QC/RegTractOverlap_” is generated, including multiple JPG files to enable visualization of tract overlap from different views. Open one of them, e.g., “_view_left_tract_overlap.jpg_”, where the different colors represent the different tractography data (as displayed below). The yellow tract is from the atlas, and the red tract shows the input tractography. This image shows the input tractography data has been registered into the atlas space (overlapping well with the atlas tractography data; see above for the tract overlap before registration).
 
          ![test image](tutorial-pics/fig_qc_reg_overlap.jpg)
 
-## 6. Tractograpy fiber clustering
+## 6. Tractography fiber clustering
     
-This step performs fiber clustering of the registered tractography data, resulting in an 800-cluster white matter parcellation according to the ORG atlas. This includes the following sub-steps: 1) initial fiber clustering of the registered tractography, and 2) outlier removal to filter false positive fibers, 3) assessesment of the hemispheric location (left, right or commissural) of each fiber per cluster, 4) transformation of the fiber clusters back to the input tractography space, and 5) separation of the clusters into left, right and commissural tracts.
+This step performs fiber clustering of the registered tractography data, resulting in an 800-cluster white matter parcellation according to the ORG atlas. This includes the following sub-steps: 1) initial fiber clustering of the registered tractography, and 2) outlier removal to filter false positive fibers, 3) assessment of the hemispheric location (left, right or commissural) of each fiber per cluster, 4) transformation of the fiber clusters back to the input tractography space, and 5) separation of the clusters into left, right and commissural tracts.
 
    - Run initial fiber clustering using “**_wm_cluster_from_atlas.py_**” 
     
@@ -180,7 +180,7 @@ This step performs fiber clustering of the registered tractography data, resulti
      ```
      wm_harden_transform.py -i -t ./TractRegistration/example-UKF-data/output_tractography/itk_txform_example-UKF-data.tfm ./FiberClustering/OutlierRemovedClusters/example-UKF-data_reg_outlier_removed/ ./FiberClustering/TransformedClusters/example-UKF-data/ /Applications/Slicer.app/Contents/MacOS/Slicer
      ```
-        > **_Note_**: In this example, we give the path to 3D Slicer under a MacOS machine. This path needs to be changed according to your computer.
+        > **_Note_**: In this example, we give the path to 3D Slicer under a macOS machine. This path needs to be changed according to your computer.
          
       - A new folder “_FiberClustering/TransformedClusters/example-UKF-data_” is generated. Inside the folder, there are 800 vtp files, which have been transformed in the input tractography space.
        
@@ -244,11 +244,11 @@ This step computes diffusion measurements of the fiber clusters and the anatomic
      wm_diffusion_measurements.py ./FiberClustering/SeparatedClusters/tracts_commissural/ ./DiffusionMeasurements/commissural_clusters.csv /Applications/Slicer4p10realease.app/Contents/Extensions-27501/SlicerDMRI/lib/Slicer-4.10/cli-modules/FiberTractMeasurements
      ```
        
-        > **_Note_**: Here, we give the path to the FiberTractMeasufrements module under MacOS. The path needs to be changed based on the operating system you are using.
+        > **_Note_**: Here, we give the path to the FiberTractMeasurements module under macOS. The path needs to be changed based on the operating system you are using.
          
       - A new folder “_DiffusionMeasurements_” is generated, containing three CSV files. Open one of them using Excel to see the diffusion measurements statistics. 
         
-        > **_Note_**: For the empty vtp file (e.g. cluster_00001 is a hemispheric cluster, and it does have fibers in the commissual category), “NAN” will be assigned.
+        > **_Note_**: For the empty vtp file (e.g. cluster_00001 is a hemispheric cluster, and it does have fibers in the commissural category), “NAN” will be assigned.
           
           ![test image](tutorial-pics/fig_csv_clusters.png)
           

--- a/utilities/wm_fix_UKF_trace.py
+++ b/utilities/wm_fix_UKF_trace.py
@@ -33,7 +33,7 @@ def fix_trace(inpd):
                 inpd.GetLines().GetNextCell(ptids)
                 for pidx in range(0, ptids.GetNumberOfIds()):
                     trace_val = array.GetTuple(ptids.GetId(pidx))[0]
-                    # inverse funcion of https://github.com/pnlbwh/ukftractography/blob/fcf83e290de9feb38e6592c2fcacc107cdc029fe/ukf/tractography.cc#L1902
+                    # inverse function of https://github.com/pnlbwh/ukftractography/blob/fcf83e290de9feb38e6592c2fcacc107cdc029fe/ukf/tractography.cc#L1902
                     trace_correct = 1 / ( numpy.tan(trace_val / 2 * 3.14) ) / 1.0e6 
 
                     if array.GetName() == 'trace1':

--- a/utilities/wm_measure_endpoint_overlap.py
+++ b/utilities/wm_measure_endpoint_overlap.py
@@ -23,7 +23,7 @@ parser.add_argument("-v", "--version",
     help="Show program's version number and exit")
 parser.add_argument(
     'inputTractDirectory',
-    help='Directory of fiber clustering results obtained by <wm_cluster_from_altas.py> of multiple subjects. Make sure only the fiber clustering results are stored in this folder, making one subdirectory corresponding to one subject.')
+    help='Directory of fiber clustering results obtained by <wm_cluster_from_atlas.py> of multiple subjects. Make sure only the fiber clustering results are stored in this folder, making one subdirectory corresponding to one subject.')
 parser.add_argument(
     'inputLabelMapDirectory',
     help='Contains the parcellation or functional areas as label map files. Make sure that the input tract files and the label map files match each other in alphabetical order.')
@@ -117,6 +117,6 @@ endpoint_txt_list = list_txt_files(args.outputDirectory)
 print("<wm_endpoint_analysis> Endpoint analysis were measured for", len(endpoint_txt_list), "subjects.")
 
 if len(tract_dir_list) != len(endpoint_txt_list):
-    print("Error: The numbers of inputs and outputs are different. Check the log file of each subeject.")
+    print("Error: The numbers of inputs and outputs are different. Check the log file of each subject.")
 else:
     os.system("rm -rf "+os.path.join(args.outputDirectory, 'log*'))


### PR DESCRIPTION
Fix miscellaneous typos and grammar across files, including hard-coded names for scripts and Slicer modules.

Use the appropriate case to refer to the `macOS` OS.