### PR TITLE
DOC: Sync the license file with the current Slicer license file content

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -1,7 +1,7 @@
 
 For more information, please see:
 
-                      http://www.slicer.org
+                      https://www.slicer.org
 
 The 3D Slicer license below is a BSD style license, with extensions
 to cover contributions and other issues specific to 3D Slicer.
@@ -79,7 +79,7 @@ Sublicense ("Contribution Agreement").
    your breach of any of the terms of this Agreement.
 
 6. YOU WARRANT THAT TO THE BEST OF YOUR KNOWLEDGE YOUR CONTRIBUTION
-   DOES NOT CONTAIN ANY CODE THAT REQURES OR PRESCRIBES AN "OPEN
+   DOES NOT CONTAIN ANY CODE THAT REQUIRES OR PRESCRIBES AN "OPEN
    SOURCE LICENSE" FOR DERIVATIVE WORKS (by way of non-limiting
    example, the GNU General Public License or other so-called
    "reciprocal" license that requires any derived work to be licensed
@@ -196,4 +196,4 @@ This Agreement shall be governed by and construed in accordance with
 the laws of The Commonwealth of Massachusetts without regard to
 principles of conflicts of law. This Agreement shall supercede and
 replace any license terms that you may have agreed to previously with
-respect to Slicer. 
+respect to Slicer.


### PR DESCRIPTION
Sync the license file with the current Slicer license file content: https://github.com/Slicer/Slicer/blob/ce1ab3d3799ca9e11cc1175f4d0c8653d4837e11/License.txt

Specifically:
- Prefer using https over http for web addresses when available.
- Fix a typo following: https://github.com/Slicer/Slicer/commit/68ff0ae7114e4378322740f117643d7513a71110
- Add a blank line at the beginning of the file and remove an unnecessary whitespace in the text.

Make the filename be all lowercase to sync with the Slicer license filename.