### PR TITLE
ENH: Add all released Python version above 3.8 until 3.11 to CI

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -11,7 +11,7 @@ jobs:
       # max-parallel: 6
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - name: Check out repository

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,16 @@
 joblib==1.1.*
 matplotlib==3.6.*
 nibabel==3.0.*
-numpy==1.20.*
+numpy==1.20.*;python_version=="3.8"
+numpy==1.21.*;python_version=="3.9"
 pandas==2.0.3
 pytest
 pytest_console_scripts
 setuptools==44.0.*
-scipy==1.4.*
-statsmodels==0.10.*
-vtk==9.1.*
+scipy==1.4.*;python_version=="3.8"
+scipy==1.5.*;python_version=="3.9"
+statsmodels==0.10.*;python_version=="3.8"
+statsmodels==0.13.*;python_version=="3.9"
+vtk==9.1.*;python_version>="3.8" and python_version<="3.9"
+vtk==9.2.*;python_version>="3.10"
 xlrd

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("requirements.txt") as f:
             external_dependencies.append(dependency)
 
 
-setup_requires = ['numpy==1.20.*']
+setup_requires = ['numpy>=1.20.0']
 setup(
     name='whitematteranalysis',
     version='0.3.0',


### PR DESCRIPTION
- ENH: Relax `numpy` install requirement version
- ENH: Add all released Python version above 3.8 until 3.11 to CI 