### PR TITLE
DOC: Add `readthedocs` documentation site infrastructure

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,28 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+  apt_packages:
+    - libblas-dev
+    - liblapack-dev
+
+# Build documentation in the doc/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ whitematteranalysis
 ===================
 
 [![test, package](https://github.com/SlicerDMRI/whitematteranalysis/actions/workflows/test_package.yaml/badge.svg?branch=master)](https://github.com/SlicerDMRI/whitematteranalysis/actions/workflows/test_package.yaml?query=branch%3Amaster)
+[![Documentation Status](https://readthedocs.org/projects/whitematteranalysis/badge/?version=latest)](https://whitematteranalysis.readthedocs.io/en/latest/?badge=latest)
 
 # Synopsis
 
@@ -27,6 +28,9 @@ Note: On macOS, to be able to use `pip`, `X-code` needs to be installed using `$
 Run `$ wm_quality_control_tractography.py --help` to test if the installation is successful.
 
 ## 3. Documentation
+
+The `whitematteranalysis` package documentation can be found at
+https://whitematteranalysis.readthedocs.io/en/latest/.
 
 * A master shell script `wm_apply_ORG_atlas_to_subject.sh` (see code [here](https://github.com/SlicerDMRI/whitematteranalysis/blob/73a7948751f49d9fda8ec84fb5caeecaeeb92621/bin/wm_apply_ORG_atlas_to_subject.sh#L1-L40)) is provided to apply an anatomically curated white matter atlas ([the ORG atlas](https://dmri.slicer.org/atlases/)), along with the computation tools provided in whitematteranalysis, to perform subject-specific tractography parcellation.
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = doc
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,97 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import re
+from datetime import datetime
+
+# import sys
+
+# sys.path.insert(0, os.path.abspath('.'))
+
+author_setup_str = "    author="
+author_email_setup_str = "    author_email="
+name_setup_str = "    name="
+version_setup_str = "    version="
+
+
+# Load the release info into a dict by explicit execution
+info = {}
+with open(os.path.abspath(os.path.join(
+        os.path.dirname(__file__), "..", "setup.py")), "r") as f:
+    for line in f:
+        if line.startswith(name_setup_str):
+            project = (
+                re.search(name_setup_str + "(.*),", line).group(1).strip("\'"))
+        elif line.startswith(author_setup_str):
+            _author = (
+                re.search(
+                    author_setup_str + "(.*),",
+                    line).group(1).strip("\'").replace("\\", "")
+            )
+        elif line.startswith(author_email_setup_str):
+            _email = (
+                re.search(
+                    author_email_setup_str + "(.*),",
+                    line).group(1).strip("\'")
+            )
+        elif line.startswith(version_setup_str):
+            _version = (
+                re.search(
+                    version_setup_str + "(.*),",
+                    line).group(1).strip("\'")
+            )
+
+# -- Project information -----------------------------------------------------
+
+copyright = f"2013-{datetime.now().year}, {_author} <{_email}>"
+author = f"{_author}s"
+
+# The full version, including alpha/beta/rc tags
+release = _version
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "sphinx.ext.autodoc",
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = []
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+# Sources
+source_suffix = ".rst"
+
+# The master toctree document.
+master_doc = "index"
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = []

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,8 @@
+Welcome to the whitematteranalysis documentation!
+=================================================
+
+.. toctree::
+    :maxdepth: 1
+
+    bin
+    utilities

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     long_description=open('README.md').read(),
     setup_requires=setup_requires,
     install_requires=setup_requires + external_dependencies,
+    extras_require={'doc': ['sphinx', 'sphinx-argparse', 'sphinx_rtd_theme']},
     scripts=list(chain.from_iterable([
         glob.glob("bin/[a-zA-Z]*.py"),
         glob.glob("utilities/[a-zA-Z]*.py"),


### PR DESCRIPTION
DOC: Add `readthedocs` documentation site infrastructure

Add `readthedocs` documentation site configuration and site index files.
Add the necessary packages to generate the documentation from the source
files, including Python module methods, and script arguments.

Add `Makefile` and `make.bat` files to build the documentation locally.

Add the reference to the `readthedocs` website and the corresponding
build badge to the `README` file.