### PR TITLE
ENH: Relax the Python package version requirements

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
+        requires: ['minimal', 'latest']
 
     steps:
     - name: Check out repository
@@ -23,6 +24,12 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Set min. dependencies
+      if: matrix.requires == 'minimal'
+      run: |
+        python -c "req = open('requirements.txt').read().replace(' >= ', ' == ') ; open('requirements.txt', 'w').write(req)"
+        python -c "req = open('setup.py').read().replace(' >= ', ' == ') ; open('setup.py', 'w').write(req)"
 
     # - name: Cache pip
     #   uses: actions/cache@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,16 @@
-joblib==1.1.*
-matplotlib==3.6.*
-nibabel==3.0.*
-numpy==1.20.*;python_version=="3.8"
-numpy==1.21.*;python_version=="3.9"
-pandas==2.0.3
+joblib>=1.1.0
+matplotlib>=3.6.0,<3.8
+nibabel>=3.0.0
+numpy>=1.20.0,<1.21.0;python_version=="3.8"
+numpy>=1.21.0;python_version=="3.9"
+pandas<2.1.0
 pytest
 pytest_console_scripts
-setuptools==44.0.*
-scipy==1.4.*;python_version=="3.8"
-scipy==1.5.*;python_version=="3.9"
-statsmodels==0.10.*;python_version=="3.8"
-statsmodels==0.13.*;python_version=="3.9"
-vtk==9.1.*;python_version>="3.8" and python_version<="3.9"
-vtk==9.2.*;python_version>="3.10"
+scipy>=1.4.0,<1.11.0;python_version=="3.8"
+scipy>=1.5.0;python_version=="3.9"
+setuptools>=44.0.0
+statsmodels>=0.10.0,<0.13.0;python_version=="3.8"
+statsmodels>=0.13.0;python_version=="3.9"
+vtk>=9.1.0,<9.2.0;python_version>="3.8" and python_version<="3.9"
+vtk>=9.2.0;python_version>="3.10"
 xlrd


### PR DESCRIPTION
Relax the Python package version requirements: constrain versions within
a range, and test the min and max versions so that there is some more
flexibility when using different package versions.