### PR TITLE
STYLE: Prefer using lowercase to name package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup
 from pkg_resources import resource_filename
 
-#    url='http://pypi.python.org/pypi/WhiteMatterAnalysis/',
+#    url='http://pypi.python.org/pypi/whitematteranalysis/',
 #    scripts=['bin/test1.py','bin/test2.py'],
 
 # ext_modules work-around: https://stackoverflow.com/a/38057196
@@ -88,7 +88,7 @@ with open("requirements.txt") as f:
 
 setup_requires = ['cython==0.29.*', 'numpy==1.20.*']
 setup(
-    name='WhiteMatterAnalysis',
+    name='whitematteranalysis',
     version='0.3.0',
     author='Fan Zhang and Lauren O\'Donnell',
     author_email='fzhang@bwh.harvard.edu; odonnell@bwh.harvard.edu',


### PR DESCRIPTION
Prefer using lowercase to name package in line with other relevant scientific computing Python packages.

Change it as well in the commented PyPI URL (note that the package was never been uploaded to PyPI, and thus, changing the package name at this stage is safe from that point of view).