### PR TITLE
DOC: Improve Markdown syntax in `README` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,27 @@ Miniconda is a nice option because it includes pip, setuptools, and all library 
 
 The following command will use pip to install whitematteranalysis from this source repository and all library dependencies:
 
-      pip install git+https://github.com/SlicerDMRI/whitematteranalysis.git
+```shell
+$ pip install git+https://github.com/SlicerDMRI/whitematteranalysis.git
+```
 
+Note: On macOS, to be able to use `pip`, `X-code` needs to be installed using `$ xcode-select --install`.
 
-  (Note: On macOS, to be able to use pip, X-code needs to be installed using `xcode-select --install`.)
-
-Run `wm_quality_control_tractography.py --help` to test if the installation is successful.
+Run `$ wm_quality_control_tractography.py --help` to test if the installation is successful.
 
 ## 3. Documentation
 
-* A master shell script ```wm_apply_ORG_atlas_to_subject.sh``` (see code [here](https://github.com/SlicerDMRI/whitematteranalysis/blob/73a7948751f49d9fda8ec84fb5caeecaeeb92621/bin/wm_apply_ORG_atlas_to_subject.sh#L1-L40)) is provided to apply an anatomically curated white matter atlas ([the ORG atlas](https://dmri.slicer.org/atlases/)), along with the computation tools provided in whitematteranalysis, to perform subject-specific tractography parcellation.
+* A master shell script `wm_apply_ORG_atlas_to_subject.sh` (see code [here](https://github.com/SlicerDMRI/whitematteranalysis/blob/73a7948751f49d9fda8ec84fb5caeecaeeb92621/bin/wm_apply_ORG_atlas_to_subject.sh#L1-L40)) is provided to apply an anatomically curated white matter atlas ([the ORG atlas](https://dmri.slicer.org/atlases/)), along with the computation tools provided in whitematteranalysis, to perform subject-specific tractography parcellation.
 
-    ```bash wm_apply_ORG_atlas_to_subject.sh -i input_tractography.vtk -o output_dir -a path_to_atlas/ORG-Atlases-v1.x -s /Applications/Slicer5.2.2.app/Contents/MacOS/Slicer -d 1 -m /Applications/Slicer5.2.2.app/Contents/Extensions-31382/SlicerDMRI/lib/Slicer-5.2/cli-modules/FiberTractMeasurements```
+```shell
+$ wm_apply_ORG_atlas_to_subject.sh \
+  -i input_tractography.vtk \
+  -o output_dir \
+  -a path_to_atlas/ORG-Atlases-v1.x \
+  -s /Applications/Slicer5.2.2.app/Contents/MacOS/Slicer \
+  -d 1 \
+  -m /Applications/Slicer5.2.2.app/Contents/Extensions-31382/SlicerDMRI/lib/Slicer-5.2/cli-modules/FiberTractMeasurements
+```
 
 * A step-by-step tutorial to explain the detailed computational process within the pipeline is provided [here](https://github.com/SlicerDMRI/whitematteranalysis/blob/master/doc/subject-specific-tractography-parcellation.md).
 


### PR DESCRIPTION
Improve Markdown syntax in `README` file:
- Use simple backticks for inline verbatim code.
- Use triple backticks and shell highlighting hint for multi-line commands.

Split long commands over multiple lines to improve readability.

Add dollar sign in terminal commands.