### PR TITLE
ENH: Discover scripts automatically

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
+import glob
 import os
+from itertools import chain
 from setuptools import setup
 from pkg_resources import resource_filename
 
@@ -40,33 +42,9 @@ setup(
     long_description=open('README.md').read(),
     setup_requires=setup_requires,
     install_requires=setup_requires + external_dependencies,
-    scripts=[
-        'bin/harden_transform_with_slicer.py',
-        'bin/wm_append_clusters.py',
-        'bin/wm_append_clusters_to_anatomical_tracts.py',
-        'bin/wm_apply_ORG_atlas_to_subject.sh',
-        'bin/wm_assess_cluster_location_by_hemisphere.py',
-        'bin/wm_cluster_volumetric_measurements.py',
-        'bin/wm_cluster_atlas.py',
-        'bin/wm_cluster_from_atlas.py',
-        'bin/wm_cluster_remove_outliers.py',
-        'bin/wm_compare_vtks.py',
-        'bin/wm_create_mrml_file.py',
-        'bin/wm_diffusion_measurements.py',
-        'bin/wm_download_anatomically_curated_atlas.py',
-        'bin/wm_harden_transform.py',
-        'bin/wm_preprocess_all.py',
-        'bin/wm_quality_control_tractography.py',
-        'bin/wm_quality_control_after_clustering.py',
-        'bin/wm_quality_control_cluster_measurements.py',
-        'bin/wm_quality_control_tract_overlap.py',
-        'bin/wm_register_multisubject_faster.py',
-        'bin/wm_register_to_atlas_new.py',
-        'bin/wm_remove_data_along_tracts.py',
-        'bin/wm_separate_clusters_by_hemisphere.py',
-        'bin/wm_tract_to_volume.py',
-        'bin/wm_vtp2vtk.py',
-        'bin/wm_change_nrrd_dir.py',
-        'testing/test_run.py'
-    ]
+    scripts=list(chain.from_iterable([
+        glob.glob("bin/[a-zA-Z]*.py"),
+        glob.glob("utilities/[a-zA-Z]*.py"),
+        # ['testing/test_run.py']
+        ]))
 )


### PR DESCRIPTION
Discover scripts automatically.
- Fixes some scripts having been missed when listing them manually.
- Add the scripts in the `utilities` folder.
- Do not add the `testing/test_run.py` test script for now as it is
  known to fail due to the testing data not being available.