### PR TITLE
BUG: Remove non-existing `version` keyword parameter in script argparser

### DIFF
--- a/bin/wm_compare_vtks.py
+++ b/bin/wm_compare_vtks.py
@@ -15,8 +15,7 @@ def _build_arg_parser():
 
     parser = argparse.ArgumentParser(
         description="Compare two tractography files to see how much registration has changed the points. The files must have the exact same size and lines and points, e.g. the original file and the file that results from applying a transform to a file.",
-        epilog="Written by Lauren O\'Donnell, odonnell@bwh.harvard.edu.  Please reference \"O'Donnell, Lauren J., and C-F. Westin. Automatic tractography segmentation using a high-dimensional white matter atlas. Medical Imaging, IEEE Transactions on 26.11 (2007): 1562-1575.\"",
-        version='1.0')
+        epilog="Written by Lauren O\'Donnell, odonnell@bwh.harvard.edu.  Please reference \"O'Donnell, Lauren J., and C-F. Westin. Automatic tractography segmentation using a high-dimensional white matter atlas. Medical Imaging, IEEE Transactions on 26.1 (2007): 1562-1575.\"")
     parser.add_argument(
         'inputFile1',
         help='A file of whole-brain tractography as vtkPolyData (.vtk or .vtp).')

--- a/utilities/wm_flatten_length_distribution.py
+++ b/utilities/wm_flatten_length_distribution.py
@@ -16,8 +16,7 @@ def _build_arg_parser():
 
     parser = argparse.ArgumentParser(
         description="Samples fibers such that the output distribution of fiber lengths is approximately flat, within the input length range.",
-        epilog="Written by Lauren O\'Donnell, odonnell@bwh.harvard.edu",
-        version='1.0')
+        epilog="Written by Lauren O\'Donnell, odonnell@bwh.harvard.edu")
     parser.add_argument(
         'inputDirectory',
         help='Contains whole-brain tractography as vtkPolyData file(s).')

--- a/utilities/wm_statistics.py
+++ b/utilities/wm_statistics.py
@@ -16,8 +16,7 @@ def _build_arg_parser():
 
     parser = argparse.ArgumentParser(
         description="Compute requested statistics comparing groups in the input groups file. Please verify your input by running wm_quality_control_cluster measurements before running this program.",
-        epilog="Written by Lauren O\'Donnell, odonnell@bwh.harvard.edu.  Please reference \"O'Donnell, Lauren J., and C-F. Westin. Automatic tractography segmentation using a high-dimensional white matter atlas. Medical Imaging, IEEE Transactions on 26.11 (2007): 1562-1575.\"",
-        version='1.0')
+        epilog="Written by Lauren O\'Donnell, odonnell@bwh.harvard.edu.  Please reference \"O'Donnell, Lauren J., and C-F. Westin. Automatic tractography segmentation using a high-dimensional white matter atlas. Medical Imaging, IEEE Transactions on 26.11 (2007): 1562-1575.\"")
     parser.add_argument(
         'inputDirectory',
         help='A directory of .csv or txt measurement files from Slicer tractography measurements.')

--- a/utilities/wm_statistics_export_data.py
+++ b/utilities/wm_statistics_export_data.py
@@ -13,8 +13,7 @@ def _build_arg_parser():
 
     parser = argparse.ArgumentParser(
         description="Export all subjects selected measures into one excel-readable file for use in statistics programs. Please verify your input by running wm_quality_control_cluster measurements before running this program.",
-        epilog="Written by Lauren O\'Donnell, odonnell@bwh.harvard.edu.  Please reference \"O'Donnell, Lauren J., and C-F. Westin. Automatic tractography segmentation using a high-dimensional white matter atlas. Medical Imaging, IEEE Transactions on 26.11 (2007): 1562-1575.\"",
-        version='1.0')
+        epilog="Written by Lauren O\'Donnell, odonnell@bwh.harvard.edu.  Please reference \"O'Donnell, Lauren J., and C-F. Westin. Automatic tractography segmentation using a high-dimensional white matter atlas. Medical Imaging, IEEE Transactions on 26.11 (2007): 1562-1575.\"")
     parser.add_argument(
         'inputDirectory',
         help='A directory of .csv or txt measurement files from Slicer tractography measurements.')

--- a/utilities/wm_transform_polydata.py
+++ b/utilities/wm_transform_polydata.py
@@ -17,8 +17,7 @@ def _build_arg_parser():
 
     parser = argparse.ArgumentParser(
         description="Applies preprocessing to input directory. Downsamples, removes short fibers. Preserves tensors and scalar point data along retained fibers.",
-        epilog="Written by Lauren O\'Donnell, odonnell@bwh.harvard.edu",
-        version='1.0')
+        epilog="Written by Lauren O\'Donnell, odonnell@bwh.harvard.edu")
     parser.add_argument(
         'inputDirectory',
         help='Contains whole-brain tractography as vtkPolyData file(s).')


### PR DESCRIPTION
Remove non-existing `version` keyword parameter in script argument parser object instantiation.

Fixes:
```
Traceback (most recent call last):
  File ".virtualenvs/wma/lib/python3.8/site-packages/pytest_console_scripts/__init__.py", line 319, in exec_script
    exec(compiled, {'__name__': '__main__'})
  File ".virtualenvs/wma/bin/wm_flatten_length_distribution.py", line 4, in <module>
    __import__('pkg_resources').run_script('whitematteranalysis==0.3.0', 'wm_flatten_length_distribution.py')
  File ".virtualenvs/wma/lib/python3.8/site-packages/pkg_resources/__init__.py", line 666, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File ".virtualenvs/wma/lib/python3.8/site-packages/pkg_resources/__init__.py", line 1462, in run_script
    exec(code, namespace, namespace)
  File ".virtualenvs/wma/lib/python3.8/site-packages/whitematteranalysis-0.3.0-py3.8.egg/EGG-INFO/scripts/wm_flatten_length_distribution.py", line 26, in <module>
    parser = argparse.ArgumentParser(
TypeError: __init__() got an unexpected keyword argument 'version'
```

and equivalent errors across scripts.