### PR TITLE
BUG: Miscellaneous cleanup for compliance PyPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include *.txt
-recursive-include docs *.txt
+recursive-include doc

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     license='LICENSE.txt',
     description='Processing of whole-brain streamline tractography.',
     long_description=open('README.md').read(),
+    long_description_content_type="text/markdown",
     setup_requires=setup_requires,
     install_requires=setup_requires + external_dependencies,
     extras_require={'doc': ['sphinx', 'sphinx-argparse', 'sphinx_rtd_theme']},

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     name='whitematteranalysis',
     version='0.3.0',
     author='Fan Zhang and Lauren O\'Donnell',
-    author_email='fzhang@bwh.harvard.edu; odonnell@bwh.harvard.edu',
+    author_email='odonnell@bwh.harvard.edu',
     packages=['whitematteranalysis'],
     license='LICENSE.txt',
     description='Processing of whole-brain streamline tractography.',


### PR DESCRIPTION
- BUG: Use a single author-email in `setup.py`
- BUG: Set the long description content type to Markdown
- BUG: Remove non-existing pattern under `doc` in `MANIFEST.in`