### PR TITLE
ENH: Remove unused `pkg_resources` module import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ import glob
 import os
 from itertools import chain
 from setuptools import setup
-from pkg_resources import resource_filename
 
 #    url='http://pypi.python.org/pypi/whitematteranalysis/',
 #    scripts=['bin/test1.py','bin/test2.py'],


### PR DESCRIPTION
Remove unused `pkg_resources` module import.

Also, `pkg_resources` is deprecated in recent `setuptools` versions.

Fixes:
```
* Getting build dependencies for wheel...
<string>:5: DeprecationWarning: pkg_resources is deprecated as an API.
See https://setuptools.pypa.io/en/latest/pkg_resources.html
* Installing packages in isolated environment... (numpy>=1.20.0, wheel)
* Building wheel...
<string>:5: DeprecationWarning: pkg_resources is deprecated as an API.
See https://setuptools.pypa.io/en/latest/pkg_resources.html
```

when trying to upload the package to TestPyPI using `$ twine upload --repository testpypi dist/*`

Documentation:
https://setuptools.pypa.io/en/latest/pkg_resources.html