### PR TITLE
BUG: Fix script names in tests

### DIFF
--- a/utilities/tests/test_wm_compute_FA_from_DWIs.py
+++ b/utilities/tests/test_wm_compute_FA_from_DWIs.py
@@ -2,5 +2,5 @@
 # -*- coding: utf-8 -*-
 
 def test_help_option(script_runner):
-    ret = script_runner.run(["wm_compute_FA_DWIs.py", "--help"])
+    ret = script_runner.run(["wm_compute_FA_from_DWIs.py", "--help"])
     assert ret.success

--- a/utilities/tests/test_wm_compute_bundle_feature_population_math.py
+++ b/utilities/tests/test_wm_compute_bundle_feature_population_math.py
@@ -3,5 +3,5 @@
 
 def test_help_option(script_runner):
     ret = script_runner.run(
-        ["test_wm_compute_bundle_feature_population_math.py", "--help"])
+        ["wm_compute_bundle_feature_population_math.py", "--help"])
     assert ret.success


### PR DESCRIPTION
Fix script names in tests.

Fixes
```
FAILED
utilities/tests/test_wm_compute_FA_DWIs.py::test_help_option[inprocess]
 - FileNotFoundError:
[Errno 2] No such file or directory: 'src/wma/wm_compute_FA_DWIs.py'
```

and
```
FAILED
utilities/tests/test_wm_compute_bundle_feature_population_math.py::test_help_option[inprocess]
 - FileNotFoundError:
[Errno 2] No such file or directory: 'src/wma/test_wm_compute_bundle_feature_population_math.py'
```

Introduced inadvertently in commits cf5ddd8 and 5974295.

Take advantage of the commit to rename one of the test scripts to honor the corresponding script name.