### PR TITLE
ENH: Specify `statsmodels` package version for Python>=3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ scipy>=1.5.0;python_version=="3.9"
 scipy>=1.9.0;python_version>="3.10"
 setuptools>=44.0.0
 statsmodels>=0.10.0,<0.13.0;python_version=="3.8"
-statsmodels>=0.13.0;python_version=="3.9"
+statsmodels>=0.13.0;python_version>="3.9"
 vtk>=9.1.0,<9.2.0;python_version>="3.8" and python_version<="3.9"
 vtk>=9.2.0;python_version>="3.10"
 xlrd


### PR DESCRIPTION
Specify `statsmodels` package version for Python>=3.10.