### PR TITLE
ENH: Install package using `pip` in GHA workflow

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -52,7 +52,7 @@ jobs:
     - name: Run tests
       run: |
         # tox --sitepackages
-        python setup.py install
+        pip install -e .
         python -c 'import whitematteranalysis'
         # coverage run --source whitematteranalysis -m pytest whitematteranalysis -o junit_family=xunit2 -v --doctest-modules --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
         pytest


### PR DESCRIPTION
Install package using `pip` in GHA workflow following the recommended way for package installation.

Prefer:
```
$ pip install -e .
```

over
```
python setup.py install
```