### PR TITLE
ENH: Test with code coverage in GHA package test workflow

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -54,8 +54,7 @@ jobs:
         # tox --sitepackages
         pip install -e .
         python -c 'import whitematteranalysis'
-        # coverage run --source whitematteranalysis -m pytest whitematteranalysis -o junit_family=xunit2 -v --doctest-modules --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
-        pytest
+        coverage run --source whitematteranalysis -m pytest -o junit_family=xunit2 -v --doctest-modules --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
 
     - name: Upload pytest test results
       uses: actions/upload-artifact@master
@@ -64,6 +63,11 @@ jobs:
         path: junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
       # Use always() to always run this step to publish test results when there are test failures
       if: always()
+
+    - name: Statistics
+      if: success()
+      run: |
+         coverage report
 
     - name: Package Setup
     # - name: Run tests with tox
@@ -74,8 +78,3 @@ jobs:
         # twine check dist/
         # tox --sitepackages
         # python -m tox
-
-    # - name: Statistics
-     # if: success()
-     # run: |
-     #    coverage report


### PR DESCRIPTION
Test with code coverage in GHA package test workflow.

Move the coverage reporting block in the workflow file closer to the testing with coverage block.