### PR TITLE
ENH: Do not `try`/`except` on non-optional imports

### DIFF
--- a/whitematteranalysis/cluster.py
+++ b/whitematteranalysis/cluster.py
@@ -8,27 +8,13 @@ implementations of fiber clustering
 import colorsys
 import os
 import pickle
+from pprint import pprint
 
 import numpy as np
+import scipy.cluster.hierarchy
+import scipy.cluster.vq
 import vtk
-
-try:
-    import scipy.cluster.hierarchy
-    import scipy.cluster.vq
-    USE_SCIPY = 1
-except ImportError:
-    USE_SCIPY = 0
-    print(f"<{os.path.basename(__file__)}> Failed to import scipy.cluster, cannot cluster.")
-    print(f"<{os.path.basename(__file__)}> Please install scipy for this functionality.")
-try:
-    from joblib import Parallel, delayed
-    USE_PARALLEL = 1
-except ImportError:
-    USE_PARALLEL = 0
-    print(f"<{os.path.basename(__file__)}> Failed to import joblib, cannot multiprocess.")
-    print(f"<{os.path.basename(__file__)}> Please install joblib for this functionality.")
-
-from pprint import pprint
+from joblib import Parallel, delayed
 
 from . import fibers, filter, io, mrml, render, similarity
 
@@ -510,7 +496,8 @@ def spectral(input_polydata, number_of_clusters=200,
             print("Silhouette Coefficient: %0.3f" % cluster_metric)
  
     else:
-        print("ERROR: Unknown centroid finder", centroid_finder)
+        raise NotImplementedError(
+            f"Workflow not implemented for centroid finder: {centroid_finder}.")
         ## # This found fewer clusters than we need to represent the anatomy well
         ## # Leave code here in case wanted in future for more testing.
         ## print '<cluster.py> Affinity Propagation clustering in embedding space.'

--- a/whitematteranalysis/register_two_subjects.py
+++ b/whitematteranalysis/register_two_subjects.py
@@ -10,19 +10,11 @@ class RegisterTractography
 """
 
 import os
-
-try:
-    import scipy.optimize
-    USE_SCIPY = 1
-except ImportError:
-    USE_SCIPY = 0
-    print(f"<{os.path.basename(__file__)}> Failed to import  scipy.optimize, cannot align or register.")
-    print(f"<{os.path.basename(__file__)}> Please install  scipy.optimize for this functionality.")
-
 import sys
 import time
 
 import numpy as np
+import scipy.optimize
 import vtk
 
 try:
@@ -270,7 +262,8 @@ class RegisterTractography:
             print("FLAG:", warnflag)
 
         else:
-            print("Unknown optimizer.")
+            raise NotImplementedError(
+                f"Workflow not implemented for optimizer: {self.optimizer}.")
 
         self.final_transform = np.divide(self.final_transform, self.transform_scaling)
 

--- a/whitematteranalysis/register_two_subjects_nonrigid.py
+++ b/whitematteranalysis/register_two_subjects_nonrigid.py
@@ -10,19 +10,11 @@ class RegisterTractographyNonrigid
 """
 
 import os
-
-try:
-    import scipy.optimize
-    USE_SCIPY = 1
-except ImportError:
-    USE_SCIPY = 0
-    print(f"<{os.path.basename(__file__)}> Failed to import  scipy.optimize, cannot align or register.")
-    print(f"<{os.path.basename(__file__)}> Please install  scipy.optimize for this functionality.")
-
 import sys
 import time
 
 import numpy as np
+import scipy.optimize
 import vtk
 
 try:
@@ -322,7 +314,8 @@ class RegisterTractographyNonrigidThinPlateSplines(wma.register_two_subjects.Reg
             print("TRANS:", self.final_transform, "FLAG:", warnflag)
 
         else:
-            print("Unknown optimizer.")
+            raise NotImplementedError(
+                f"Workflow not implemented for optimizer: {self.optimizer}.")
 
         if self.verbose:
             print("O:", self.objective_function_values)

--- a/whitematteranalysis/register_two_subjects_nonrigid_bsplines.py
+++ b/whitematteranalysis/register_two_subjects_nonrigid_bsplines.py
@@ -10,20 +10,11 @@ class RegisterTractographyNonrigid
 """
 
 import os
-
-try:
-    import scipy.optimize
-    USE_SCIPY = 1
-except ImportError:
-    USE_SCIPY = 0
-    print(f"<{os.path.basename(__file__)}> Failed to import  scipy.optimize, cannot align or register.")
-    print(f"<{os.path.basename(__file__)}> Please install  scipy.optimize for this functionality.")
-
-import os
 import sys
 import time
 
 import numpy as np
+import scipy.optimize
 import vtk
 import vtk.util.numpy_support
 
@@ -335,7 +326,8 @@ class RegisterTractographyNonrigid(wma.register_two_subjects.RegisterTractograph
             print("TRANS:", self.final_transform, "FLAG:", warnflag)
 
         else:
-            print("Unknown optimizer.")
+            raise NotImplementedError(
+                f"Workflow not implemented for optimizer: {self.optimizer}.")
 
         progress_file = open(self.progress_filename, 'a')
         self.total_time = time.time() - self.start_time


### PR DESCRIPTION
Do not `try`/`except` on non-optional imports.

Also, raise an exception if the corresponding option is not found.