### PR TITLE
STYLE: Prefer importing `nibabel` as `nib`

### DIFF
--- a/bin/wm_cluster_volumetric_measurements.py
+++ b/bin/wm_cluster_volumetric_measurements.py
@@ -4,7 +4,7 @@
 import argparse
 import os
 
-import nibabel
+import nibabel as nib
 import numpy
 import vtk
 from nibabel.affines import apply_affine
@@ -68,7 +68,7 @@ def main():
         print("Output directory", args.outputDirectory, "does not exist, creating it.")
         os.makedirs(outdir)
     
-    input_volume = nibabel.load(inputvol)
+    input_volume = nib.load(inputvol)
     print(f'<{os.path.basename(__file__)}> Input volume shape:', input_volume.get_data().shape)
     
     input_vtk_list = wma.io.list_vtk_files(inputdir)
@@ -182,9 +182,9 @@ def main():
         str_out = str_out + '\n' + str_line
     
         if args.outputLabelmap:
-            volume_new = nibabel.Nifti1Image(new_voxel_data, input_volume.affine, input_volume.header)
+            volume_new = nib.Nifti1Image(new_voxel_data, input_volume.affine, input_volume.header)
             output_labelmap = os.path.join(outdir, vtk_file_name+'.nii.gz')
-            nibabel.save(volume_new, output_labelmap)
+            nib.save(volume_new, output_labelmap)
     
     output_file = open(output_stats_file, 'w')
     output_file.write(str_out)

--- a/bin/wm_tract_to_volume.py
+++ b/bin/wm_tract_to_volume.py
@@ -4,7 +4,7 @@
 import argparse
 import os
 
-import nibabel
+import nibabel as nib
 import numpy
 import vtk
 from nibabel.affines import apply_affine
@@ -149,16 +149,16 @@ def main():
             
         return new_voxel_data
     
-    volume = nibabel.load(args.refvolume)
+    volume = nib.load(args.refvolume)
     print(f'<{os.path.basename(__file__)}>', args.refvolume, ', input volume shape: ', volume.get_fdata().shape)
     
     inpd = wma.io.read_polydata(args.inputVTK)
     
     new_voxel_data = convert_cluster_to_volume(inpd, volume, measure=args.measure)
     
-    volume_new = nibabel.Nifti1Image(new_voxel_data, volume.affine, volume.header)
+    volume_new = nib.Nifti1Image(new_voxel_data, volume.affine, volume.header)
     
-    nibabel.save(volume_new, args.outputVol)
+    nib.save(volume_new, args.outputVol)
     
     print('Done: save tract map to', args.outputVol)
 


### PR DESCRIPTION
Prefer importing `nibabel` as `nib` to be consistent with current common practice and for the sake of compactness.