### PR TITLE
ENH: Remove unnecessary/uninformative version optional arg in scripts

### DIFF
--- a/bin/harden_transform_with_slicer.py
+++ b/bin/harden_transform_with_slicer.py
@@ -50,10 +50,6 @@ def _build_arg_parser():
     parser = argparse.ArgumentParser(
         description="Harden transform with Slicer.",
         epilog="Written by Fan Zhang, fzhang@bwh.harvard.edu")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
     parser.add_argument(
         'polydata',
         help='')

--- a/bin/wm_assess_cluster_location_by_hemisphere.py
+++ b/bin/wm_assess_cluster_location_by_hemisphere.py
@@ -29,10 +29,6 @@ def _build_arg_parser():
         description="Assess if a fiber within the clusters belongs to left hemispheric, right hemispheric, or commissural tracts. "
                     "This code needs to be run in the ATLAS space, where the brain is clustered at the RAS origin. ",
         epilog="Written by Fan Zhang (fzhang@bwh.harvard.edu) and Lauren O\'Donnell (odonnell@bwh.harvard.edu). Please reference \"O'Donnell, Lauren J., and C-F. Westin. Automatic tractography segmentation using a high-dimensional white matter atlas. Medical Imaging, IEEE Transactions on 26.11 (2007): 1562-1575.\"")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
     parser.add_argument(
         'inputDirectory',
         help='A directory of clustered whole-brain tractography as vtkPolyData (.vtk or .vtp).')

--- a/bin/wm_cluster_atlas.py
+++ b/bin/wm_cluster_atlas.py
@@ -20,10 +20,6 @@ def main():
     parser = argparse.ArgumentParser(
         description="Runs clustering of tractography for multiple subjects to create an atlas. This tract atlas can then be applied to the complete set of fibers from individual subjects of interest. To make it possible to cluster the high number of fibers, this code uses random sampling and the Nystrom method as described in the reference below.",
         epilog="Written by Lauren O\'Donnell, odonnell@bwh.harvard.edu.  Please reference \"O'Donnell, Lauren J., and C-F. Westin. Automatic tractography segmentation using a high-dimensional white matter atlas. Medical Imaging, IEEE Transactions on 26.11 (2007): 1562-1575.\"")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
     parser.add_argument(
         'inputDirectory',
         help='A directory of (already registered) whole-brain tractography as vtkPolyData (.vtk or .vtp).')

--- a/bin/wm_cluster_from_atlas.py
+++ b/bin/wm_cluster_from_atlas.py
@@ -17,10 +17,6 @@ def _build_arg_parser():
     parser = argparse.ArgumentParser(
         description="Clusters tractography (propagates clusters) from a cluster atlas (a multi-subject/multi-atlas cluster representation).",
         epilog="Written by Lauren O\'Donnell, odonnell@bwh.harvard.edu.  Please reference \"O'Donnell, Lauren J., and C-F. Westin. Automatic tractography segmentation using a high-dimensional white matter atlas. Medical Imaging, IEEE Transactions on 26.11 (2007): 1562-1575.\"")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
     parser.add_argument(
         'inputFile',
         help='A file of whole-brain tractography as vtkPolyData (.vtk or .vtp).')

--- a/bin/wm_cluster_remove_outliers.py
+++ b/bin/wm_cluster_remove_outliers.py
@@ -25,10 +25,6 @@ def _build_arg_parser():
     parser = argparse.ArgumentParser(
         description="Removes outliers in a subject dataset that was clustered from a cluster atlas. This script uses the atlas to identifies and remove outliers in each cluster of the subject. The atlas must be the same one used to cluster the subject dataset",
         epilog="Written by Lauren O\'Donnell, odonnell@bwh.harvard.edu.  Please reference \"O'Donnell, Lauren J., and C-F. Westin. Automatic tractography segmentation using a high-dimensional white matter atlas. Medical Imaging, IEEE Transactions on 26.11 (2007): 1562-1575.\"")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
     parser.add_argument(
         'inputDirectory',
         help='A directory containing subject clusters (.vtp). Please note that file separator should not be provided at the end of the input so that the program can automatically recognize subject ID from the input folder name.')

--- a/bin/wm_cluster_volumetric_measurements.py
+++ b/bin/wm_cluster_volumetric_measurements.py
@@ -17,10 +17,6 @@ def _build_arg_parser():
     parser = argparse.ArgumentParser(
         description="Compute measurements of a cluster based on a provided volumetric scalar map (e.g. an FA image).",
         epilog="Written by Fan Zhang")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
     parser.add_argument(
         'inputDirectory',
         help='Directory of input VTK/VTP files.')

--- a/bin/wm_diffusion_measurements.py
+++ b/bin/wm_diffusion_measurements.py
@@ -13,10 +13,6 @@ def _build_arg_parser():
     parser = argparse.ArgumentParser(
         description="Compute diffusion scalar measurements (such as FA, MD, etc). This script reports the mean statistics of each fiber cluster (or fiber tract) within the input folder.",
         epilog="Written by Fan Zhang (fzhang@bwh.harvard.edu)")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
     parser.add_argument(
         'inputDirectory',
         help='Directory of fiber clustering results obtained by <wm_cluster_from_atlas.py> of multiple subjects. Make sure only the fiber clustering results are stored in this folder, making one subdirectory corresponding to one subject.')

--- a/bin/wm_harden_transform.py
+++ b/bin/wm_harden_transform.py
@@ -14,10 +14,6 @@ def _build_arg_parser():
     parser = argparse.ArgumentParser(
         description="Harden transform with Slicer.",
         epilog="Written by Fan Zhang, fzhang@bwh.harvard.edu")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
     parser.add_argument(
         'inputDirectory',
         help='Directory of input VTK/VTP files that are going to be transformed.')

--- a/bin/wm_quality_control_after_clustering.py
+++ b/bin/wm_quality_control_after_clustering.py
@@ -26,10 +26,6 @@ def _build_arg_parser():
     parser = argparse.ArgumentParser(
         description="Quality control of fiber clustering results across multiple subjects.",
         epilog="Written by Fan Zhang, fzhang@bwh.harvard.edu")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
     parser.add_argument(
         'inputDirectory',
         help='Directory of fiber clustering results obtained by <wm_cluster_from_atlas.py> of multiple subjects. Make sure only the fiber clustering results are stored in this folder, making one subdirectory corresponding to one subject.')

--- a/bin/wm_separate_clusters_by_hemisphere.py
+++ b/bin/wm_separate_clusters_by_hemisphere.py
@@ -29,10 +29,6 @@ def _build_arg_parser():
         description="Separate each cluster into left/right/commissural tracts based on the fiber location information computed by <wm_assess_cluster_location_by_hemisphere.py>. "
                     "The output is three directories of fiber bundles according to left hemisphere, right hemisphere, and commissural tracts. ",
         epilog="Written by Fan Zhang (fzhang@bwh.harvard.edu) and Lauren O\'Donnell (odonnell@bwh.harvard.edu). Please reference \"O'Donnell, Lauren J., and C-F. Westin. Automatic tractography segmentation using a high-dimensional white matter atlas. Medical Imaging, IEEE Transactions on 26.11 (2007): 1562-1575.\"")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
     parser.add_argument(
         'inputDirectory',
         help='A directory of clustered whole-brain tractography as vtkPolyData (.vtk or .vtp).')

--- a/bin/wm_tract_to_volume.py
+++ b/bin/wm_tract_to_volume.py
@@ -17,11 +17,6 @@ def _build_arg_parser():
     parser = argparse.ArgumentParser(
         description="Convert a fiber tract or cluster (vtk) to a voxel-wise fiber density image (nii.gz). ",
         epilog="Written by Fan Zhang")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
-    
     parser.add_argument(
         'inputVTK',
         help='Input VTK/VTP file that is going to be converted.')

--- a/utilities/wm_assess_cluster_location.py
+++ b/utilities/wm_assess_cluster_location.py
@@ -15,10 +15,6 @@ def _build_arg_parser():
     parser = argparse.ArgumentParser(
         description="Decide a cluster belonging to commissural or hemispheric in the atlas.",
         epilog="Written by Fan Zhang, fzhang@bwh.harvard.edu")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
     parser.add_argument(
         'inputAtlasDirectory',
         help='Directory of the fiber clustering atlas. An output CSV file will be generated, showing the location of each fiber cluster: left-hemisphere, right-hemisphere, commissural, or Not Given if the fibers of a cluster are relatively even distributed in these three regions. ')

--- a/utilities/wm_compute_FA_from_DWIs.py
+++ b/utilities/wm_compute_FA_from_DWIs.py
@@ -24,10 +24,6 @@ def _build_arg_parser():
     parser = argparse.ArgumentParser(
         description="Measures mean FA, etc. in tractography clusters in a directory.",
         epilog="Written by Lauren O\'Donnell, odonnell@bwh.harvard.edu.  Please reference \"O'Donnell, Lauren J., and C-F. Westin. Automatic tractography segmentation using a high-dimensional white matter atlas. Medical Imaging, IEEE Transactions on 26.11 (2007): 1562-1575.\"")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
     parser.add_argument(
         'inputDirectoryDWI',
         help='A directory of DWIs (nhdr or nrrd).')

--- a/utilities/wm_compute_TAP.py
+++ b/utilities/wm_compute_TAP.py
@@ -16,10 +16,6 @@ def _build_arg_parser():
     parser = argparse.ArgumentParser(
         description="Compute Tract Anatomical Profile",
         epilog="Written by Fan Zhang, zhangfanmark@gmail.com.")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
     parser.add_argument(
         'inputDirectory',
         help='A directory containing subdirectories for all clustered subjects.')

--- a/utilities/wm_extract_cluster.py
+++ b/utilities/wm_extract_cluster.py
@@ -16,10 +16,6 @@ def _build_arg_parser():
     parser = argparse.ArgumentParser(
         description="Grab one cluster from within all subject directories and rename to include subject ID. Output all clusters into the output directory",
         epilog="Written by Lauren O\'Donnell, odonnell@bwh.harvard.edu.  Please reference \"O'Donnell, Lauren J., and C-F. Westin. Automatic tractography segmentation using a high-dimensional white matter atlas. Medical Imaging, IEEE Transactions on 26.11 (2007): 1562-1575.\"")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
     parser.add_argument(
         'cluster', type=int,
         help='The cluster number you would like to copy for all subjects.')

--- a/utilities/wm_extract_clusters_by_endpoints.py
+++ b/utilities/wm_extract_clusters_by_endpoints.py
@@ -14,10 +14,6 @@ def _build_arg_parser():
     parser = argparse.ArgumentParser(
         description="Extract fiber clusters that connect to one particular region, such as one cortical parcel or one fMRI functional area. This is based on the results from <wm_measure_endpoint_overlap.py>.",
         epilog="Written by Fan Zhang, fzhang@bwh.harvard.edu")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
     parser.add_argument(
         'inputDirectory',
         help='Contains endpoint overlap percentage measurement as txt files, which are computed from <wm_measure_endpoint_overlap.py>.')

--- a/utilities/wm_laterality_all.py
+++ b/utilities/wm_laterality_all.py
@@ -13,10 +13,6 @@ def _build_arg_parser():
     parser = argparse.ArgumentParser(
         description="Applies white matter laterality pipeline to input directory.",
         epilog="Written by Lauren O\'Donnell, odonnell@bwh.harvard.edu")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
     parser.add_argument(
         'inputDirectory',
         help='Contains whole-brain tractography as vtkPolyData file(s).')

--- a/utilities/wm_measure_all_clusters.py
+++ b/utilities/wm_measure_all_clusters.py
@@ -14,10 +14,6 @@ def _build_arg_parser():
     parser = argparse.ArgumentParser(
         description="Measures mean FA, etc. in tractography clusters in a directory.",
         epilog="Written by Lauren O\'Donnell, odonnell@bwh.harvard.edu.  Please reference \"O'Donnell, Lauren J., and C-F. Westin. Automatic tractography segmentation using a high-dimensional white matter atlas. Medical Imaging, IEEE Transactions on 26.11 (2007): 1562-1575.\"")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
     parser.add_argument(
         'inputDirectory',
         help='A directory of tractography as vtkPolyData (.vtk or .vtp).')

--- a/utilities/wm_measure_endpoint_overlap.py
+++ b/utilities/wm_measure_endpoint_overlap.py
@@ -15,10 +15,6 @@ def _build_arg_parser():
     parser = argparse.ArgumentParser(
         description="Measure overlaps of fiber clusters with cortical parcellation or fMRI functional areas. This is based on the 3D Slicer module FiberEndPointFromLabelMap.",
         epilog="Written by Fan Zhang, fzhang@bwh.harvard.edu")
-    parser.add_argument("-v", "--version",
-        action="version", default=argparse.SUPPRESS,
-        version='1.0',
-        help="Show program's version number and exit")
     parser.add_argument(
         'inputTractDirectory',
         help='Directory of fiber clustering results obtained by <wm_cluster_from_atlas.py> of multiple subjects. Make sure only the fiber clustering results are stored in this folder, making one subdirectory corresponding to one subject.')


### PR DESCRIPTION
Remove unnecessary/uninformative version optional argument in scripts: the necessary information about a given version is determined by the corresponding git commit hash or package tag version, and the corresponding comments.