### PR TITLE
DOC: Add Markdown tutorial files to the documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,7 @@ build:
     - liblapack-dev
   jobs:
     pre_build:
+      - pip install --upgrade myst-parser
       - sphinx-apidoc -f -o doc .
 
 # Build documentation in the doc/ directory with Sphinx

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,6 +66,7 @@ release = _version
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "myst_parser",
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
 ]
@@ -79,7 +80,7 @@ templates_path = []
 exclude_patterns = ["*tests*"]
 
 # Sources
-source_suffix = ".rst"
+source_suffix = [".rst", ".md"]
 
 # The master toctree document.
 master_doc = "index"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,6 +17,13 @@ tools.
    bin
    utilities
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Tutorials
+
+   bundles
+   subject-specific-tractography-parcellation
+
 Indices and tables
 ==================
 


### PR DESCRIPTION
Add Markdown tutorial files to the documentation.

Add the necessary Sphinx extensions and source suffixes for Sphinx to be able to render the Markdown files.

Documentation:
https://www.sphinx-doc.org/en/master/usage/markdown.html