### PR TITLE
DOC: Prefer using `furo` theme for Sphinx documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ build:
     - liblapack-dev
   jobs:
     pre_build:
-      - pip install --upgrade myst-parser
+      - pip install --upgrade myst-parser furo
       - sphinx-apidoc -f -o doc .
 
 # Build documentation in the doc/ directory with Sphinx

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -91,7 +91,7 @@ master_doc = "index"
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_rtd_theme"
+html_theme = "furo"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Prefer using `furo` theme for Sphinx documentation.

Install the `furo` package as a pre-build step so that it is available for `readthedocs`.

Documentation:
https://pradyunsg.me/furo/quickstart/