### PR TITLE
BUG: Remove spare `f` in an f-string

### DIFF
--- a/bin/wm_harden_transform.py
+++ b/bin/wm_harden_transform.py
@@ -115,7 +115,7 @@ def main():
             str_inverse = 0
     
         print(f"<{os.path.basename(__file__)}> Transforming: {polydata}")
-        cmd = f"{slicer_path} --no-main-window --python-script $(which harden_transform_with_slicer.py) {polydata} {transform} {str(str_inverse)} {outdir} --python-code 'slicer.app.quit()' >> f{os.path.join(outdir, 'log.txt 2>&1')}"
+        cmd = f"{slicer_path} --no-main-window --python-script $(which harden_transform_with_slicer.py) {polydata} {transform} {str(str_inverse)} {outdir} --python-code 'slicer.app.quit()' >> {os.path.join(outdir, 'log.txt 2>&1')}"
     
         os.system(cmd)
     


### PR DESCRIPTION
Remove a spare `f` when redirecting the output of a 3D Slicer command
 call using an f-string in the transform hardening script.

Inadvertently introduced in commit ac6040f.