### PR TITLE
ENH: Fix artifact upload naming conflict

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -59,9 +59,9 @@ jobs:
         coverage run --source whitematteranalysis -m pytest -o junit_family=xunit2 -v --doctest-modules --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
 
     - name: Upload pytest test results
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v4
       with:
-        name: pytest-results-${{ runner.os }}-${{ matrix.python-version }}
+        name: pytest-results-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.requires }}
         path: junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
       # Use always() to always run this step to publish test results when there are test failures
       if: always()


### PR DESCRIPTION
Fix artifact upload naming conflict:
- Add the label of the required version mode to the artifact name.
- Pin action version.

In v4, artifacts are immutable (unless deleted), so each of the uploaded artifacts needs to have a different name.

Fixes:
```
Error: Failed to CreateArtifact: Received non-retryable error:
Failed request: (409) Conflict:
an artifact with this name already exists on the workflow run
```

raised for example in
https://github.com/SlicerDMRI/whitematteranalysis/actions/runs/7407939750