### PR TITLE
STYLE: Fix filename and dirname creation floating point formatting

### DIFF
--- a/whitematteranalysis/congeal_multisubject.py
+++ b/whitematteranalysis/congeal_multisubject.py
@@ -193,9 +193,9 @@ class MultiSubjectRegistration:
             
         # make a directory for the current iteration
         if self.mode == "Nonrigid":
-            dirname = f"iteration_{self.total_iterations:05d}_sigma_{self.sigma:03d}_grid_{self.nonrigid_grid_resolution:03d}"
+            dirname = f"iteration_{self.total_iterations:05d}_sigma_{int(self.sigma):03d}_grid_{int(self.nonrigid_grid_resolution):03d}"
         else:
-            dirname = f"iteration_{self.total_iterations:05d}_sigma_{self.sigma:03d}"
+            dirname = f"iteration_{self.total_iterations:05d}_sigma_{int(self.sigma):03d}"
 
         outdir = os.path.join(self.output_directory, dirname)
         if not os.path.exists(outdir):
@@ -346,9 +346,9 @@ class MultiSubjectRegistration:
         if have_mpl:
             plt.figure(0)
             if self.mode == "Nonrigid":
-                fname_fig_base = f"iteration_{self.total_iterations:05d}_sigma_{self.sigma:03d}_grid_{self.nonrigid_grid_resolution:03d}"
+                fname_fig_base = f"iteration_{self.total_iterations:05d}_sigma_{int(self.sigma):03d}_grid_{int(self.nonrigid_grid_resolution):03d}"
             else:
-                fname_fig_base = f"iteration_{self.total_iterations:05d}_sigma_{self.sigma:03d}_"
+                fname_fig_base = f"iteration_{self.total_iterations:05d}_sigma_{int(self.sigma):03d}_"
             # Place the legend below the plot so it does not overlap it when there are many subjects
             #lgd = plt.legend(loc='upper center', bbox_to_anchor=(0.5, -0.15), fancybox=False, shadow=False, ncol=1)
             fname_fig = f'objectives_per_subject_{fname_fig_base}.pdf'
@@ -405,9 +405,9 @@ class MultiSubjectRegistration:
             # Make a directory for the current iteration.
             # This directory name must match the one created above in the iteration.
             if self.mode == "Nonrigid":
-                dirname = f"iteration_{self.total_iterations:05d}_sigma_{self.sigma:03d}_grid_{self.nonrigid_grid_resolution:03d}"
+                dirname = f"iteration_{self.total_iterations:05d}_sigma_{int(self.sigma):03d}_grid_{int(self.nonrigid_grid_resolution):03d}"
             else:
-                dirname = f"iteration_{self.total_iterations:05d}_sigma_{self.sigma:03d}"
+                dirname = f"iteration_{self.total_iterations:05d}_sigma_{int(self.sigma):03d}"
             outdir = os.path.join(self.output_directory, dirname)
             if not os.path.exists(outdir):
                 os.makedirs(outdir)

--- a/whitematteranalysis/congeal_to_atlas.py
+++ b/whitematteranalysis/congeal_to_atlas.py
@@ -108,7 +108,7 @@ class SubjectToAtlasRegistration:
         self.total_iterations += 1
 
         # make a directory for the current iteration
-        dirname = f"iteration_{self.total_iterations:05d}_sigma_{ self.sigma:05d}"
+        dirname = f"iteration_{self.total_iterations:05d}_sigma_{int(self.sigma):05d}"
         outdir = os.path.join(self.output_directory, dirname)
         if not os.path.exists(outdir):
             os.makedirs(outdir)
@@ -163,7 +163,7 @@ class SubjectToAtlasRegistration:
 
         if intermediate_save:
             # make a directory for the current iteration
-            dirname = f"iteration_{self.total_iterations:05d}_sigma_{self.sigma:05d}"
+            dirname = f"iteration_{self.total_iterations:05d}_sigma_{int(self.sigma):05d}"
             outdir = os.path.join(self.output_directory, dirname)
             if not os.path.exists(outdir):
                 os.makedirs(outdir)


### PR DESCRIPTION
Fix formatting of numbers that can be floats when creating filenames and dirnames: when transitioning to f-strings (commit ac6040f), it was assumed that `sigma` and `nonrigid_grid_resolution` would be integers, based on the existing formatting. However, these attributes can be set to non-integer values. The pre-f-string transition solution, e.g.:
```
"iteration_%05d_sigma_%05d" % (self.total_iterations, self.sigma)
```

trimmed the decimal part, and thus, for e.g. `total_iterations` 20 and `sigma` 7.5, it would produce:
```
'iteration_00020_sigma_00007'
```

With the introduction of f-strings, i.e.
```
f"iteration_{self.total_iterations:05d}_sigma_{self.sigma:05d}"
```

this would produce an error, since the `sigma` floating point value cannot be formatted as an integer:
```
{ValueError}ValueError("Unknown format code 'd' for object of type
'float'")
```

This patch set fixes the error by adopting the previous behavior: it trims the decimal part.