### PR TITLE
ENH: Fix workflow actions warnings linked to `Node.js`

### DIFF
--- a/.github/workflows/check_format.yaml
+++ b/.github/workflows/check_format.yaml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -21,7 +21,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -33,7 +33,7 @@ jobs:
         python -c "req = open('setup.py').read().replace(' >= ', ' == ') ; open('setup.py', 'w').write(req)"
 
     # - name: Cache pip
-    #   uses: actions/cache@v2
+    #   uses: actions/cache@v4
     #   id: cache
     #   with:
     #     path: ${{ env.pythonLocation }}


### PR DESCRIPTION
Fix format linter and testing  workflow actions warnings linked to `Node.js`: bump `actions/setup-python` to v5.

Take advantage of the commit to bump `actions/cache` to v4.

Fixes:
```
Node.js 16 actions are deprecated.
 Please update the following actions to use Node.js 20:
 actions/setup-python@v4.
 For more information see:
 https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

raised for example in:
https://github.com/SlicerDMRI/whitematteranalysis/actions/runs/9719632509