### PR TITLE
STYLE: Fix registration process id string floating point formatting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ nibabel>=3.0.0
 numpy>=1.20.0,<1.21.0;python_version=="3.8"
 numpy>=1.21.0;python_version>="3.9"
 pandas<2.1.0
+pillow<10.4.0
 scipy>=1.4.0,<1.11.0;python_version=="3.8"
 scipy>=1.5.0;python_version=="3.9"
 scipy>=1.9.0;python_version>="3.10"

--- a/whitematteranalysis/congeal_multisubject.py
+++ b/whitematteranalysis/congeal_multisubject.py
@@ -476,7 +476,7 @@ def congeal_multisubject_inner_loop(mean, subject, initial_transform, mode, sigm
     # Set up registration objects and parameters that are specific to affine vs nonrigid
     if mode == "Affine" or mode == "Rigid":
         register = wma.register_two_subjects.RegisterTractography()
-        register.process_id_string = f"_subject_{subject_idx:05d}_iteration_{iteration_count:05d}_sigma_{sigma:03d}"
+        register.process_id_string = f"_subject_{subject_idx:05d}_iteration_{iteration_count:05d}_sigma_{int(sigma):03d}"
         if mode == "Rigid":
             register.mode = [1, 1, 0, 0] 
         # Make sure the initial iterations are performed with Cobyla.
@@ -488,7 +488,7 @@ def congeal_multisubject_inner_loop(mean, subject, initial_transform, mode, sigm
         register = wma.register_two_subjects_nonrigid_bsplines.RegisterTractographyNonrigid()
         register.nonrigid_grid_resolution = grid_resolution
         register.initialize_nonrigid_grid()
-        register.process_id_string = f"_subject_{subject_idx:05d}_iteration_{iteration_count:05d}_sigma_{sigma:03d}_grid_{grid_resolution:03d}"
+        register.process_id_string = f"_subject_{subject_idx:05d}_iteration_{iteration_count:05d}_sigma_{int(sigma):03d}_grid_{int(grid_resolution):03d}"
 
     else:
         print("ERROR: Unknown registration mode")


### PR DESCRIPTION
Fix formatting of numbers that can be floats when creating the registration process id string: when transitioning to f-strings (commit https://github.com/SlicerDMRI/whitematteranalysis/commit/ac6040fcf77ac132d0fc4a071af9d80240f7f577), it was assumed that `sigma` and `grid_resolution` would be integers, based on the existing formatting. However, these attributes can be set to non-integer values. The pre-f-string transition solution, e.g.:
```
"(...)_sigma_%03d_grid_%03d" % (subject_idx, iteration_count, sigma, grid_resolution)
```

trimmed the decimal part, and thus, for e.g. `sigma` 7.5 and `grid_resolution` 1.5, it would produce:
```
'(...)_sigma_007_grid_001'
```

With the introduction of f-strings, i.e.
```
f"(...)_sigma_{sigma:03d}_grid_{grid_resolution:03d}"
```

this would produce an error, since the `sigma` and `grid_resolution` floating point value cannot be formatted as an integer:
```
{ValueError}ValueError("Unknown format code 'd' for object of type
'float'")
```

This patch set fixes the error by adopting the previous behavior: it trims the decimal part.

Left behind in commit https://github.com/SlicerDMRI/whitematteranalysis/commit/d7c6bd8e3eea33e4efb023daf7aef1bd9e544074.

Limit the Pillow dependency to <10.4.0. Solves:
```
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/PIL/_typing.py", line 10, in <module>
    NumpyArray = npt.NDArray[Any]
AttributeError: module 'numpy.typing' has no attribute 'NDArray'
```

raised for example at:
https://github.com/SlicerDMRI/whitematteranalysis/actions/runs/9821374452/job/27116961065?pr=236#step:6:175