### PR TITLE
Put wm_apply_ORG_atlas_to_subject.sh in Python's bin/ directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     extras_require={'doc': ['sphinx', 'sphinx-argparse', 'sphinx_rtd_theme']},
     scripts=list(chain.from_iterable([
         glob.glob("bin/[a-zA-Z]*.py"),
+        glob.glob("bin/[a-zA-Z]*.sh"),
         glob.glob("utilities/[a-zA-Z]*.py"),
         ])),
     package_data={'whitematteranalysis':


### PR DESCRIPTION
The current `setup.py` does not put all `whitematteranalysis/bin/*` scripts into installed Python's `bin/` directory. As a result, your primary script `wm_apply_ORG_atlas_to_subject.sh` is not put in Python's `bin/` directory. But this was not the case in prior version of whitematteranalysis. This breaking change was introduced by this commit: https://github.com/SlicerDMRI/whitematteranalysis/commit/ed933b38cfd5c9de15f3d0b59e37f5696c52e354. We are submitting a fix for this.

cc @yrathi @ryanZurrin

