### PR TITLE
Update requirements.txt to accept more python/vtk versions

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -11,7 +11,7 @@ jobs:
       # max-parallel: 6
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
         requires: ['minimal', 'latest']
 
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,5 @@ scipy>=1.9.0;python_version>="3.10"
 setuptools>=44.0.0
 statsmodels>=0.10.0,<0.13.0;python_version=="3.8"
 statsmodels>=0.13.0;python_version>="3.9"
-vtk>=9.1.0,<9.2.0;python_version>="3.8" and python_version<="3.9"
-vtk>=9.2.0;python_version>="3.10"
+vtk>=9.1.0;python_version>="3.9"
 xlrd


### PR DESCRIPTION
Possible fix for the issue reported here:

https://discourse.slicer.org/t/slicer-doesnt-open-after-installing-slicerwma-extension/42356